### PR TITLE
fix: non verbose output format

### DIFF
--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -1105,7 +1105,11 @@ impl DltMessage {
                     }
                 }
                 _ => {
-                    write!(&mut text, "{} {:x?}", message_id, &payload)?;
+                    // write in dlt-viewer format [<msg id>] ascii chars| hex dump e.g. [4711] CID|43 49 44
+                    write!(&mut text, "[{}] ", message_id)?;
+                    crate::utils::buf_as_printable_ascii_to_write(&mut text, payload, '-')?;
+                    write!(&mut text, "|")?;
+                    crate::utils::buf_as_hex_to_write(&mut text, payload)?;
                 }
             }
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -28,6 +28,23 @@ static CHARS_HEX_LOW: [char; 16] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 ];
 
+/// output as buffer as printable ascii to a (char) writer.
+/// Each byte between [0x20...=0x7e] is printed. Others are replaced by the replacement_char.
+pub fn buf_as_printable_ascii_to_write(
+    writer: &mut impl std::fmt::Write,
+    buf: &[u8],
+    replacement_char: char,
+) -> Result<(), std::fmt::Error> {
+    for item in buf.iter() {
+        if *item >= 0x20 && *item <= 0x7e {
+            writer.write_char(*item as char)?;
+        } else {
+            writer.write_char(replacement_char)?;
+        }
+    }
+    Ok(())
+}
+
 /// output a buffer as hex dump to a (char) writer.
 /// Each byte is output as two lower-case digits.
 /// A space is output between each byte.
@@ -442,6 +459,21 @@ mod tests {
         assert_eq!(utc_time.date().day(), 1);
         assert_eq!(utc_time.date().month(), 1);
         assert_eq!(utc_time.date().year(), 1970);
+    }
+
+    #[test]
+    fn buf_as_ascii() {
+        let mut s = String::new();
+        buf_as_printable_ascii_to_write(&mut s, &[], '-').unwrap();
+        assert_eq!(s.len(), 0);
+
+        buf_as_printable_ascii_to_write(
+            &mut s,
+            &[0x00_u8, 0x1f, 0x20, 0x40, 0x7c, 0x7e, 0x7f, 0xff],
+            '-',
+        )
+        .unwrap();
+        assert_eq!(s, "-- @|~--");
     }
 
     #[test]


### PR DESCRIPTION
Use non-verbose default output as dlt-viewer.
Messages covered by non-verbose plugin remain unchanged.