### PR TITLE
feat(suspend): add detection of suspend/resume lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Rust crate provides a library and tools to help you to handle automotive DL
 ## Features
 
 - Open DLT files of any size.
-- **Lifecycle detection** feature.
+- **Lifecycle detection** feature including detection (a bit heuristic) of "SUSPEND/RESUME" lifecycles for ECUs with suspend-to-ram implementations.
 - **Sorting by timestamp** taking the lifecycles into account.
 - **Filter**...
 
@@ -35,7 +35,7 @@ adlt convert <dlt_file>
 ...
 have 3 lifecycles:
 LC#  1: ECU1 2021/06/24 08:50:58.529663 - 08:53:51 #   26523 <sw version if contained as GET_SW_VERSION response>
-LC#  2: ECU1 2021/06/24 08:54:29.957936 - 08:55:08 #  181337 <sw version>
+LC#  2: ECU1 2021/06/24 08:54:29 RESUME - 08:55:08 #  181337 <sw version>
 LC#  3: DLOG 2021/06/24 08:54:44.945600 - 08:54:44 #       1
 ```
 Output/extract a specific lifecycle into file sorted by timestamps per lifecycle:

--- a/src/bin/adlt/convert.rs
+++ b/src/bin/adlt/convert.rs
@@ -431,9 +431,15 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                         "LC#{:3}: {:4} {} - {} #{:8}{} {}",
                         lc.id(),
                         lc.ecu,
-                        Local
-                            .from_utc_datetime(&adlt::utils::utc_time_from_us(lc.start_time))
-                            .format("%Y/%m/%d %H:%M:%S%.6f"),
+                        if lc.is_resume() {
+                            Local
+                                .from_utc_datetime(&adlt::utils::utc_time_from_us(lc.resume_time()))
+                                .format("%Y/%m/%d %H:%M:%S RESUME")
+                        } else {
+                            Local
+                                .from_utc_datetime(&adlt::utils::utc_time_from_us(lc.start_time))
+                                .format("%Y/%m/%d %H:%M:%S%.6f")
+                        },
                         Local
                             .from_utc_datetime(&adlt::utils::utc_time_from_us(lc.end_time()))
                             .format("%H:%M:%S"),

--- a/src/bin/adlt/remote.rs
+++ b/src/bin/adlt/remote.rs
@@ -475,6 +475,13 @@ impl FileContext {
 ///   - Stop streaming from the requested stream_id.
 /// - `close`
 ///   - Closes the file and releases any resources associated. Afterwards new files can be opened.
+/// - `query`
+///   - Similar as stream but stops automatically.
+/// - `stream_binary_search`
+///   - binary search e.g. with time within the msgs returning closest index of a msg of the stream
+/// - `stream_window`
+///   - change the window for an existing stream
+
 fn process_incoming_text_message<T: Read + Write>(
     log: &slog::Logger,
     t: String,
@@ -886,6 +893,11 @@ fn process_file_context<T: Read + Write>(
                                 ecu: lc.ecu.as_u32le(),
                                 nr_msgs: lc.nr_msgs,
                                 start_time: lc.start_time,
+                                resume_time: if lc.is_resume() {
+                                    Some(lc.resume_time())
+                                } else {
+                                    None
+                                },
                                 end_time: lc.end_time(),
                                 sw_version: lc.sw_version.to_owned(),
                             })

--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::str::FromStr;
 
+use crate::utils::US_PER_SEC;
 use control_msgs::{parse_ctrl_log_info_payload, parse_ctrl_sw_version_payload};
 
 /// todo use perfo ideas from https://lise-henry.github.io/articles/optimising_strings.html
@@ -203,7 +204,7 @@ impl DltStorageHeader {
     }
 
     fn reception_time_us(&self) -> u64 {
-        (self.secs as u64 * 1_000_000) + self.micros as u64
+        (self.secs as u64 * US_PER_SEC) + self.micros as u64
     }
     #[allow(dead_code)]
     fn reception_time_ms(&self) -> u64 {
@@ -239,14 +240,14 @@ impl DltStandardHeader {
             len: u16::from_be_bytes([buf[2], buf[3]]), // all big endian includes std.header, ext header and the payload
         };
         // [Dlt104] check the version number. We expect 0x1 currently
-        let dlt_vers = sh.dlt_vers();
+        /* let dlt_vers = sh.dlt_vers();
         match dlt_vers {
             1 => (),
             _ => {
-                eprintln!("DltStandardHeader with unsupported version {}!", dlt_vers);
+                // eprintln!("DltStandardHeader with unsupported version {}!", dlt_vers);
                 // todo return None? / set len to 0, exthdr,... to false
             }
-        }
+        } */
 
         Some(sh)
     }
@@ -331,7 +332,7 @@ impl DltStandardHeader {
     }
 
     /// returns the dlt version from header. Currently only 0x1 should be supported.
-    fn dlt_vers(&self) -> u8 {
+    pub fn dlt_vers(&self) -> u8 {
         (self.htyp >> 5) & 0x07
     }
 
@@ -1683,7 +1684,7 @@ mod tests {
         #[test]
         fn from_msg1() {
             let mut m = DltMessage::for_test_rcv_tms_ms(0, 0);
-            m.reception_time_us = (1585231328 * 1_000_000) + 1_000;
+            m.reception_time_us = (1585231328 * US_PER_SEC) + 1_000;
             m.ecu = DltChar4::from_buf(b"ECU1");
             let shdr = DltStorageHeader::from_msg(&m);
             assert_eq!(shdr.secs, 1585231328); // 26.3.2020 14:02:08 gmt

--- a/src/utils/asc2dltmsgiterator.rs
+++ b/src/utils/asc2dltmsgiterator.rs
@@ -9,7 +9,7 @@ use crate::{
         DLT_STD_HDR_HAS_ECU_ID, DLT_STD_HDR_HAS_EXT_HDR, DLT_STD_HDR_HAS_TIMESTAMP,
         DLT_STD_HDR_VERSION, SERVICE_ID_GET_LOG_INFO,
     },
-    utils::hex_to_bytes,
+    utils::{hex_to_bytes, US_PER_SEC},
 };
 use chrono::NaiveDateTime;
 use lazy_static::lazy_static;
@@ -129,7 +129,7 @@ where
                         let timestamp = &cap_str[loc_timestamp.0..loc_timestamp.1];
                         let dot_idx = timestamp.find('.').unwrap_or_default();
                         let timestamp_us: u64 =
-                            (timestamp[0..dot_idx].parse::<u64>().unwrap_or_default() * 1_000_000)
+                            (timestamp[0..dot_idx].parse::<u64>().unwrap_or_default() * US_PER_SEC)
                                 + timestamp[dot_idx + 1..].parse::<u64>().unwrap_or_default();
                         let loc_can_id = self.capture_locations.get(2).unwrap();
                         // we map the can_id to the ECU to be used:

--- a/src/utils/remote_types.rs
+++ b/src/utils/remote_types.rs
@@ -8,6 +8,7 @@ pub struct BinLifecycle {
     pub start_time: u64,
     pub end_time: u64,
     pub sw_version: Option<String>,
+    pub resume_time: Option<u64>, // if it was a resumed lifecycle. start_time refers to the reference time for the timestamp_dms of the msgs. This time should be shown to the user.
 }
 
 #[derive(Encode)]


### PR DESCRIPTION
Added a detection for suspend/resume lifecycles from ECUs using suspend-to-ram.
Those lifecycles start after some time gap with the timestamp monotonically increasing
instead of starting from 0.
Currently the reception times need to be interrupted for at least 10s to be
identified / checked for a suspend/resume lifecycle.
The detection is important as otherwise the calculated absolute time for
those messages is wrong as the messages seem to belong to the prev. lifecycle
and thus the monotonic timestamp is added as a offset to the first lifecycle start time.