### PR TITLE
feat(anon): add anon option to convert

### DIFF
--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -1587,7 +1587,7 @@ pub fn parse_dlt_with_storage_header(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::*;
+    use crate::{to_endian_vec, utils::*};
 
     mod dlt_char4 {
         use super::*;
@@ -2356,16 +2356,6 @@ mod tests {
             m.payload_as_text().unwrap(),
             "42 -21555 304297029 -1152355238854392056"
         );
-    }
-
-    macro_rules! to_endian_vec {
-        ($x:expr, $i:expr) => {
-            if $i {
-                $x.to_be_bytes().to_vec()
-            } else {
-                $x.to_le_bytes().to_vec()
-            }
-        };
     }
 
     #[test]

--- a/src/plugins/anonymize.rs
+++ b/src/plugins/anonymize.rs
@@ -1,0 +1,183 @@
+// copyright Matthias Behr, (c) 2022
+//
+// todos:
+
+use crate::{
+    dlt::{
+        DltChar4, DltMessage, DLT_SCOD_UTF8, DLT_TYPE_INFO_STRG, SERVICE_ID_GET_LOG_INFO,
+        SERVICE_ID_GET_SOFTWARE_VERSION,
+    },
+    plugins::plugin::{Plugin, PluginState},
+};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+#[derive(Debug)]
+pub struct ApidData {
+    apid: DltChar4,
+    ctid_map: HashMap<DltChar4, DltChar4>,
+}
+
+#[derive(Debug)]
+pub struct EcuData {
+    ecu: DltChar4,
+}
+
+#[derive(Debug)]
+pub struct AnonymizePlugin {
+    name: String,
+    enabled: bool,
+    state: Arc<PluginState>,
+    ecu_map: HashMap<DltChar4, EcuData>,
+    apid_maps: HashMap<DltChar4, HashMap<DltChar4, ApidData>>, // map new_ecu ->map old_apid -> new ApidData
+}
+
+impl AnonymizePlugin {
+    pub fn new(name: &str) -> AnonymizePlugin {
+        AnonymizePlugin {
+            name: name.to_owned(),
+            enabled: true,
+            state: Arc::new(PluginState::default()),
+            ecu_map: HashMap::new(),
+            apid_maps: HashMap::new(),
+        }
+    }
+
+    fn ecu_anon(&mut self, msg: &mut DltMessage) {
+        if self.ecu_map.contains_key(&msg.ecu) {
+            msg.ecu = self.ecu_map.get(&msg.ecu).unwrap().ecu.to_owned();
+        } else {
+            let new_ecu = DltChar4::from_str(format!("E{:03}", self.ecu_map.len() + 1).as_str())
+                .unwrap_or_else(|_| DltChar4::from_buf(b"E99A"));
+            // todo, what if that key exists already? (overflow...) handle properly (not creating new EcuData)
+            self.ecu_map.insert(msg.ecu, EcuData { ecu: new_ecu });
+            msg.ecu = new_ecu;
+        }
+    }
+
+    fn apid_ctid_anon(&mut self, msg: &mut DltMessage) {
+        if let Some(cur_apid) = msg.apid() {
+            let apid_map = self.apid_maps.entry(msg.ecu).or_default();
+            if !apid_map.contains_key(cur_apid) {
+                let new_apid = DltChar4::from_str(format!("A{:03}", apid_map.len() + 1).as_str())
+                    .unwrap_or_else(|_| DltChar4::from_buf(b"A99A"));
+                apid_map.insert(
+                    *cur_apid,
+                    ApidData {
+                        apid: new_apid,
+                        ctid_map: HashMap::new(),
+                    },
+                );
+            };
+            let apid_data = apid_map.get_mut(cur_apid).unwrap(); // does always exist
+
+            // ctid does always exist if apid exists
+            let cur_ctid = msg.ctid().unwrap();
+            let new_ctid = if apid_data.ctid_map.contains_key(cur_ctid) {
+                *apid_data.ctid_map.get(cur_ctid).unwrap()
+            } else {
+                let new_ctid =
+                    DltChar4::from_str(format!("C{:03}", apid_data.ctid_map.len() + 1).as_str())
+                        .unwrap_or_else(|_| DltChar4::from_buf(b"C99A"));
+                apid_data.ctid_map.insert(*cur_ctid, new_ctid);
+                new_ctid
+            };
+
+            if let Some(extended_header) = msg.extended_header.as_mut() {
+                extended_header.apid = apid_data.apid;
+                extended_header.ctid = new_ctid;
+            }
+        }
+    }
+
+    fn ctrl_msgs_anon(&mut self, msg: &mut DltMessage) {
+        if msg.is_ctrl_response() {
+            let mut args = msg.into_iter();
+            let message_id_arg = args.next();
+            let message_id = match message_id_arg {
+                Some(a) => {
+                    if a.is_big_endian {
+                        u32::from_be_bytes(a.payload_raw.get(0..4).unwrap().try_into().unwrap())
+                    } else {
+                        u32::from_le_bytes(a.payload_raw.get(0..4).unwrap().try_into().unwrap())
+                    }
+                }
+                None => 0,
+            };
+            match message_id {
+                SERVICE_ID_GET_SOFTWARE_VERSION => {
+                    let sw_version = "adlt --anon removed sw_version";
+                    let payload = vec![
+                        crate::to_endian_vec!(message_id, msg.is_big_endian()),
+                        vec![0u8], // ret code
+                        crate::to_endian_vec!(sw_version.len() as u32, msg.is_big_endian()),
+                        sw_version.as_bytes().to_vec(),
+                    ];
+                    msg.payload = payload.into_iter().flatten().collect::<Vec<u8>>();
+                }
+                SERVICE_ID_GET_LOG_INFO => {
+                    // insert just a payload with the message id (so its corrupt...)
+                    msg.payload = crate::to_endian_vec!(message_id, msg.is_big_endian());
+                }
+                _ => {} // keep unmodified
+            }
+        }
+    }
+    fn payload_anon(&mut self, msg: &mut DltMessage) {
+        if !msg.is_ctrl_request() && !msg.is_ctrl_response() {
+            // todo might exclude other than log as well (nw trace,...)
+            if !msg.is_verbose() {
+                if msg.payload.len() >= 4 {
+                    // keep only the msg id
+                    msg.payload = msg.payload[0..4].to_owned();
+                }
+            } else {
+                // insert sample string
+                let sample_payload = "--anon";
+                let payload = vec![
+                    crate::to_endian_vec!(
+                        (DLT_TYPE_INFO_STRG | DLT_SCOD_UTF8),
+                        msg.is_big_endian()
+                    ),
+                    crate::to_endian_vec!((sample_payload.len() + 1) as u16, msg.is_big_endian()),
+                    sample_payload.as_bytes().to_vec(),
+                    vec![0u8], // zero term
+                ];
+                msg.payload = payload.into_iter().flatten().collect::<Vec<u8>>();
+            }
+        }
+    }
+}
+
+impl<'a> Plugin for AnonymizePlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn state(&self) -> Arc<PluginState> {
+        self.state.clone()
+    }
+
+    fn process_msg(&mut self, msg: &mut DltMessage) -> bool {
+        if !self.enabled {
+            return true;
+        }
+        // anonymize...
+        self.ecu_anon(msg);
+        self.apid_ctid_anon(msg);
+        self.ctrl_msgs_anon(msg);
+        self.payload_anon(msg);
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn basic() {
+        // todo add tests
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,6 +1,35 @@
+pub mod anonymize;
 pub mod can;
 pub mod factory;
 pub mod non_verbose;
 pub mod plugin;
 pub mod rewrite;
 pub mod someip;
+
+use crate::dlt::DltMessage;
+use plugin::Plugin;
+
+/// read all msgs from inflow, have all plugins process the msg.
+/// if any plugin returns false processing of that msg is stopped and the msg
+/// is not forwarded to outflow. Otherwise msg is forwarded to outflow.
+pub fn plugins_process_msgs(
+    inflow: std::sync::mpsc::Receiver<DltMessage>,
+    outflow: std::sync::mpsc::Sender<DltMessage>,
+    mut plugins_active: Vec<Box<dyn Plugin + Send>>,
+) -> Result<Vec<Box<dyn Plugin + Send>>, std::sync::mpsc::SendError<DltMessage>> {
+    for mut msg in inflow {
+        // pass the message through the plugins (sequentially, not parallel)
+        let mut forward_msg = true;
+        for plugin in &mut plugins_active {
+            let plugin = plugin.as_mut();
+            if !plugin.process_msg(&mut msg) {
+                forward_msg = false;
+                break;
+            }
+        }
+        if forward_msg {
+            outflow.send(msg)?;
+        }
+    }
+    Ok(plugins_active)
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -140,6 +140,20 @@ pub fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
     }
 }
 
+/// convert a type that supports to_be/le_bytes into a vec
+/// first param is the type to be output as vec
+/// 2nd param indicates whether big_endianess is to be used.
+#[macro_export]
+macro_rules! to_endian_vec {
+    ($x:expr, $i:expr) => {
+        if $i {
+            $x.to_be_bytes().to_vec()
+        } else {
+            $x.to_le_bytes().to_vec()
+        }
+    };
+}
+
 pub enum BufferElementsAmount {
     NumberElements(usize),
 }


### PR DESCRIPTION
Add a --anon option to convert. This is only a test feature that creates
DLT files where all data is anonymized:
- ECU, APID, CTID names and descriptions
- SW-Version
- Payload set to "--anon" for verbose msgs
- non verbose msgs reduced to the non verbose msg id.
This feature can be used to generate test DLT files
to verify the lifecycle detection algorithm.
This feature should be used to report lifecycle detection bugs.