### PR TITLE
feat(convert): file transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ This Rust crate provides a library and tools to help you to handle automotive DL
 - **Filter**...
 
 - **remote** server support: serve requests via wss. E.g. used with [DLT-Logs Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=mbehr1.dlt-logs).
-- builtin **plugins** e.g. for SOME/IP payload decoding (currently only for remote server) and **rewrite**ing of message timestamp or payload text.
+- builtin **plugins** e.g. for 
+  - non-verbose message decoding (remote only)
+  - SOME/IP payload decoding (remote only),
+  - **rewrite**ing of message timestamp or payload text (remote only),
+  - **file transfer** extraction/detection (remote & console).
 
 ## Usage examples
 
@@ -49,6 +53,27 @@ Output only messages fitting to a filter into a new file:
 # or it can be in dlt-viewer dlf format (xml file with <?xml...><dltfilter><filter>... )
 adlt convert -f <filter_file> -o <new_file> <dlt_file> # export all messages fitting to filter_file sorted into new_file
 # lifecycle filters -l ... or sorting --sort can be applied as well!
+```
+
+Show lifecycles and embedded file transfers:
+```sh
+adlt convert --file_transfer=true --file_transfer_apid SYS --file_transfer_ctid FILE <dlt_file>
+```
+
+Export all core dumps to directory 'dumps' from a set of DLT files:
+```sh
+adlt convert --file_transfer='core*.gz' --file_transfer_path dumps --file_transfer_apid SYS --file_transfer_ctid FILE '**/*.dlt'
+```
+```
+...
+LC# 35: ECU1 2020/12/19 10:29:22.158128 - 10:29:39 #   15115 
+have 6 file transfers:
+LC# 12: 'context.1584997735.controller.812.txt', 60kb 
+LC# 12: 'core.1584997735.controller.812.gz', 115kb , saved as: 'dumps/core.1584997735.controller.812.gz'
+LC# 20: 'context.1585074417.controller.802.txt', 60kb 
+LC# 20: 'core.1585074417.controller.802.gz', 115kb , saved as: 'dumps/core.1585074417.controller.802.gz'
+LC# 35: 'screenshot_20741013-092935_KOMBI.png', 7kb 
+LC# 35: 'screenshot_20741013-092935_HUD.png', 1kb 
 ```
 
 ## Known Issues

--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -1196,8 +1196,11 @@ impl DltMessage {
         DltMessage::from_headers(1, sh, stdh, &add_header_buf, payload_buf.to_vec())
     }
 
-    #[cfg(test)]
     /// return a verbose dltmessage with the noar and payload
+    ///
+    /// should only be used for testing
+    ///
+    /// ECU1/APID/CTID is used
     pub fn get_testmsg_with_payload(big_endian: bool, noar: u8, payload_buf: &[u8]) -> DltMessage {
         let sh = DltStorageHeader {
             secs: 0,
@@ -1255,15 +1258,15 @@ pub struct DltMessageArgIterator<'a> {
 /// DLT argument encoding mask for type lengths DLT_TYLE_*
 const DLT_TYPE_INFO_MASK_TYLE: u32 = 0x0000000f;
 
-pub(crate) const DLT_TYPE_INFO_BOOL: u32 = 0x00000010;
-pub(crate) const DLT_TYPE_INFO_SINT: u32 = 0x00000020;
-pub(crate) const DLT_TYPE_INFO_UINT: u32 = 0x00000040;
-pub(crate) const DLT_TYPE_INFO_FLOA: u32 = 0x00000080;
+pub const DLT_TYPE_INFO_BOOL: u32 = 0x00000010;
+pub const DLT_TYPE_INFO_SINT: u32 = 0x00000020;
+pub const DLT_TYPE_INFO_UINT: u32 = 0x00000040;
+pub const DLT_TYPE_INFO_FLOA: u32 = 0x00000080;
 /// DLT argument encoding for array of standard types
 const DLT_TYPE_INFO_ARAY: u32 = 0x00000100;
 
-pub(crate) const DLT_TYPE_INFO_STRG: u32 = 0x00000200;
-pub(crate) const DLT_TYPE_INFO_RAWD: u32 = 0x00000400;
+pub const DLT_TYPE_INFO_STRG: u32 = 0x00000200;
+pub const DLT_TYPE_INFO_RAWD: u32 = 0x00000400;
 /// DLT argument encoding for additional information to a variable (name and unit)
 const DLT_TYPE_INFO_VARI: u32 = 0x00000800;
 /// DLT argument encoding for FIXP encoding with quantization and offset
@@ -1275,10 +1278,10 @@ const DLT_TYPE_INFO_STRU: u32 = 0x00004000;
 /// DLT argument encoding mask for the string types DLT_SCOD_*
 const DLT_TYPE_INFO_MASK_SCOD: u32 = 0x00038000;
 
-pub(crate) const DLT_TYLE_8BIT: u8 = 1;
-pub(crate) const DLT_TYLE_16BIT: u8 = 2;
-pub(crate) const DLT_TYLE_32BIT: u8 = 3;
-pub(crate) const DLT_TYLE_64BIT: u8 = 4;
+pub const DLT_TYLE_8BIT: u8 = 1;
+pub const DLT_TYLE_16BIT: u8 = 2;
+pub const DLT_TYLE_32BIT: u8 = 3;
+pub const DLT_TYLE_64BIT: u8 = 4;
 const DLT_TYLE_128BIT: u8 = 5;
 
 pub const DLT_SCOD_ASCII: u32 = 0x00000000;
@@ -1288,7 +1291,7 @@ pub const DLT_SCOD_BIN: u32 = 0x00018000;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DltArg<'a> {
-    pub(crate) type_info: u32, // in host endianess already
+    pub type_info: u32,        // in host endianess already
     pub is_big_endian: bool,   // for the payload raw
     pub payload_raw: &'a [u8], // data within is
 }

--- a/src/plugins/file_transfer.rs
+++ b/src/plugins/file_transfer.rs
@@ -907,8 +907,11 @@ fn arg_as_string(arg: &crate::dlt::DltArg) -> Result<String, ()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dlt::{
-        DLT_TYLE_16BIT, DLT_TYLE_32BIT, DLT_TYLE_64BIT, DLT_TYPE_INFO_RAWD, DLT_TYPE_INFO_STRG,
+    use crate::{
+        dlt::{
+            DLT_TYLE_16BIT, DLT_TYLE_32BIT, DLT_TYLE_64BIT, DLT_TYPE_INFO_RAWD, DLT_TYPE_INFO_STRG,
+        },
+        utils::payload_from_args,
     };
 
     use super::*;
@@ -1320,45 +1323,6 @@ mod tests {
             std::fs::metadata(&file_path).unwrap().len(),
             b"data".len() as u64
         );
-    }
-
-    // todo could make this a real lib function (serialize DltArg)
-    fn payload_from_args<'a>(args: &'a [DltArg<'a>]) -> Vec<u8> {
-        if !args.is_empty() {
-            let mut payload = Vec::new();
-
-            // use endianess from first one:
-            let big_endian = args[0].is_big_endian;
-            // serialize the args
-            // type_info, len and payload
-            for arg in args {
-                let persist_len_u16 =
-                    if arg.type_info & (DLT_TYPE_INFO_STRG | DLT_TYPE_INFO_RAWD) != 0 {
-                        arg.payload_raw.len() as u16
-                    } else {
-                        0u16
-                    };
-
-                let type_info = if big_endian {
-                    arg.type_info.to_be_bytes()
-                } else {
-                    arg.type_info.to_le_bytes()
-                };
-                payload.extend_from_slice(&type_info);
-                if persist_len_u16 > 0 {
-                    payload.extend_from_slice(&if big_endian {
-                        persist_len_u16.to_be_bytes()
-                    } else {
-                        persist_len_u16.to_le_bytes()
-                    })
-                };
-                payload.extend_from_slice(arg.payload_raw);
-            }
-
-            payload
-        } else {
-            vec![]
-        }
     }
 
     #[test]


### PR DESCRIPTION
Support file transfer extraction from adlt convert function. Can extract specific/globbed files into a directory. Existing files wont be overwritten. This leads to the problem that transferred files with similar name cannot be extracted (only the first).