### PR TITLE
feat(filetransfer): show files sorted by name as well

### DIFF
--- a/src/bin/adlt/convert.rs
+++ b/src/bin/adlt/convert.rs
@@ -725,7 +725,11 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                     // output the files detected:
                     if let Some(tree_items) = state.value["treeItems"].as_array() {
                         if !tree_items.is_empty() {
-                            writeln!(writer_screen, "have {} file transfers:", tree_items.len())?;
+                            writeln!(
+                                writer_screen,
+                                "have {} file transfers:",
+                                tree_items.len() - 1 // need to remove the Sorted...
+                            )?;
                         }
 
                         for item in tree_items {


### PR DESCRIPTION
Added a "Sorted by name" tree-view folder that contains the file transfers sorted by name and not as the others by occurrence in the logs.