### PR TITLE
fix(can): avoid overlapping timestamps

### DIFF
--- a/benches/dlt_benches.rs
+++ b/benches/dlt_benches.rs
@@ -224,6 +224,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         buf_reader,
                         namespace,
                         None,
+                        None,
                     );
                     for msg in it.by_ref() {
                         messages_processed += 1;
@@ -248,6 +249,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         messages_processed,
                         buf_reader,
                         namespace,
+                        None,
                         None,
                     );
                     let it = SortingMultiReaderIterator::new(0, vec![it]);
@@ -275,6 +277,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         buf_reader,
                         namespace,
                         None,
+                        None,
                     );
                     let it = SortingMultiReaderIterator::new_or_single_it(0, vec![it]);
                     for msg in it {
@@ -299,7 +302,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                             buf_capacity,
                             DLT_MAX_STORAGE_MSG_SIZE,
                         );
-                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None)
+                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None)
                     });
 
                     let it = SequentialMultiIterator::new(0, its);
@@ -325,7 +328,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                             buf_capacity,
                             DLT_MAX_STORAGE_MSG_SIZE,
                         );
-                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None)
+                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None)
                     });
 
                     let it = SequentialMultiIterator::new_or_single_it(0, its);

--- a/benches/util_benches.rs
+++ b/benches/util_benches.rs
@@ -99,7 +99,7 @@ pub fn asc_iterator1(c: &mut Criterion) {
     group.bench_function("asc_iterator 10k", |b| {
         let namespace = get_new_namespace();
         b.iter(|| {
-            let mut it = Asc2DltMsgIterator::new(0, &buf[0..read_size], namespace, None);
+            let mut it = Asc2DltMsgIterator::new(0, &buf[0..read_size], namespace, None, None);
             let mut iterated_msgs: u64 = 0;
             for _m in &mut it {
                 iterated_msgs += 1;

--- a/src/lifecycle/mod.rs
+++ b/src/lifecycle/mod.rs
@@ -1694,6 +1694,7 @@ mod tests {
             buf_reader,
             get_new_namespace(),
             None,
+            None,
         );
         for msg in it.by_ref() {
             messages_processed += 1;

--- a/tests/can_example2a.asc
+++ b/tests/can_example2a.asc
@@ -1,0 +1,7 @@
+date Thu Apr 20 10:25:26 AM 2023
+base hex timestamps absolute
+no internal events logged
+//BusMapping: CANFD 1 = ECU_CAN_FD 559
+
+0.646664 CANFD 1 Rx 2d   1 0 9 12 28 f6 ff 7f ff 7f ff 7f ff 7f 11 11 0 0 3000 0 0 0 0 0
+77.774615 CANFD 1 Rx 70   1 0 a 16 64 c0 ff fc cf ff 00 00 00 00 00 00 00 ff ff ff 0 0 3000 0 0 0 0 0

--- a/tests/can_example2b.asc
+++ b/tests/can_example2b.asc
@@ -1,0 +1,7 @@
+date Thu Apr 20 10:26:43 AM 2023
+base hex timestamps absolute
+no internal events logged
+//BusMapping: CANFD 1 = ECU_CAN_FD 559
+
+0.777048 CANFD 1 Rx 8d   1 0 8 8 fc ff ff ff ff ff ff ff 0 0 3000 0 0 0 0 0
+226.640617 CANFD 1 Rx 543   1 0 2 2 00 01 0 0 3000 0 0 0 0 0


### PR DESCRIPTION
If multiple CAN files are opened the messages had been wrongly detected as interleaved with the msgs from the first file.
This is due to the abs time having only second granularity and the monotonic timestamps starting from zero.
Fixed by introducing a time reference from first file used for all following files.
Changed the handling of neg. timestamps for multiple files as well. Changes do only affect use-cases with multiple CAN files opened from same CAN channel.