### PR TITLE
feat(remote): send stream infos

### DIFF
--- a/src/utils/remote_types.rs
+++ b/src/utils/remote_types.rs
@@ -55,10 +55,20 @@ pub struct BinCtidInfo {
 }
 
 #[derive(Encode, bincode::Decode)]
+pub struct BinStreamInfo {
+    // todo change with index
+    pub stream_id: u32,
+    pub nr_stream_msgs: u32,
+    pub nr_file_msgs_processed: u32,
+    pub nr_file_msgs_total: u32,
+}
+
+#[derive(Encode, bincode::Decode)]
 pub enum BinType {
     FileInfo(BinFileInfo),
     Lifecycles(Vec<BinLifecycle>),
     DltMsgs((u32, Vec<BinDltMsg>)), // stream id and Vec
     EacInfo(Vec<BinEcuStats>),
     PluginState(Vec<String>), // serialized json from each plugin with generation update
+    StreamInfo(BinStreamInfo),
 }


### PR DESCRIPTION
Send the following info per stream:
- number of messages for this stream
- number of messages processed from that file(s)
- number of messages total for that file(s).

Added optimization to:
- process streams in chunk of max 1mio msgs
- end processing of stream command for auto ending streams once the max. number of msgs is achieved. Previously the command filtered all existing logs first and then stoppped as soon as enough logs had been transferred.