### PR TITLE
ci: remove windows_gnu build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux, linux-arm, linux-aarch64, macos, macos-arm, win-msvc, win-gnu, win32-msvc]
+        build: [linux, linux-arm, linux-aarch64, macos, macos-arm, win-msvc, win32-msvc]
         include:
         - build: linux
           os: ubuntu-latest
@@ -96,10 +96,6 @@ jobs:
           os: windows-2019
           rust: stable
           target: x86_64-pc-windows-msvc
-        - build: win-gnu
-          os: windows-2019
-          rust: stable-x86_64-gnu
-          target: x86_64-pc-windows-gnu
         - build: win32-msvc
           os: windows-2019
           rust: stable


### PR DESCRIPTION
Currently fails with linker error and we dont need it anyhow.