### PR TITLE
feat(logcat): add first support for logcat files

### DIFF
--- a/benches/dlt_benches.rs
+++ b/benches/dlt_benches.rs
@@ -225,6 +225,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         namespace,
                         None,
                         None,
+                        None,
                     );
                     for msg in it.by_ref() {
                         messages_processed += 1;
@@ -249,6 +250,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         messages_processed,
                         buf_reader,
                         namespace,
+                        None,
                         None,
                         None,
                     );
@@ -278,6 +280,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                         namespace,
                         None,
                         None,
+                        None,
                     );
                     let it = SortingMultiReaderIterator::new_or_single_it(0, vec![it]);
                     for msg in it {
@@ -302,7 +305,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                             buf_capacity,
                             DLT_MAX_STORAGE_MSG_SIZE,
                         );
-                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None)
+                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None, None)
                     });
 
                     let it = SequentialMultiIterator::new(0, its);
@@ -328,7 +331,7 @@ pub fn dlt_iterator1(c: &mut Criterion) {
                             buf_capacity,
                             DLT_MAX_STORAGE_MSG_SIZE,
                         );
-                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None)
+                        get_dlt_message_iterator("dlt", 0, buf_reader, namespace, None, None, None)
                     });
 
                     let it = SequentialMultiIterator::new_or_single_it(0, its);

--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -221,7 +221,7 @@ pub(crate) const DLT_STD_HDR_HAS_TIMESTAMP: u8 = 1 << 4;
 
 pub(crate) const DLT_STD_HDR_VERSION: u8 = 0x1 << 5; // 3 bits (5,6,7) max.  [Dlt299]
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DltStandardHeader {
     pub htyp: u8,
     pub mcnt: u8,
@@ -388,6 +388,7 @@ impl DltStandardHeader {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
 pub enum DltMessageLogType {
     Fatal = 1,
     Error,
@@ -541,7 +542,7 @@ impl DltExtendedHeader {
 /// anyhow prepare a type so that it can be easily changed later.
 pub type DltMessageIndexType = u32;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DltMessage {
     pub index: DltMessageIndexType,
     pub reception_time_us: u64, // from storage header, ms would be sufficent but needs same 64 bit

--- a/src/lifecycle/mod.rs
+++ b/src/lifecycle/mod.rs
@@ -1695,6 +1695,7 @@ mod tests {
             get_new_namespace(),
             None,
             None,
+            None,
         );
         for msg in it.by_ref() {
             messages_processed += 1;

--- a/src/utils/logcat2dltmsgiterator.rs
+++ b/src/utils/logcat2dltmsgiterator.rs
@@ -1,0 +1,418 @@
+use lazy_static::lazy_static;
+use regex::{CaptureLocations, Regex};
+use slog::{debug, error, warn};
+/// todos
+/// [] insert apid descriptions with full tag
+/// [] think about a better way to handle multiple files opened. currently they might be wrongly sorted as the timestamp is added as offset
+///    we'd want the last log from a file to have the recorded time = calculated time
+/// [] support other formats than monotonic timestamp
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    io::{BufRead, Lines},
+    str::FromStr,
+    sync::RwLock,
+};
+
+use crate::{
+    dlt::{
+        DltChar4, DltExtendedHeader, DltMessage, DltMessageIndexType, DltMessageLogType,
+        DltStandardHeader, DLT_EXT_HEADER_SIZE, DLT_MIN_STD_HEADER_SIZE, DLT_STD_HDR_BIG_ENDIAN,
+        DLT_STD_HDR_HAS_ECU_ID, DLT_STD_HDR_HAS_EXT_HDR, DLT_STD_HDR_HAS_TIMESTAMP,
+        DLT_STD_HDR_VERSION,
+    },
+    utils::utc_time_from_us,
+};
+
+use super::US_PER_SEC;
+
+pub struct LogCat2DltMsgIterator<'a, R> {
+    lines: Lines<R>, // todo could optimize with e.g. stream_iterator for &str instead of string copies!
+    pub index: DltMessageIndexType,
+    namespace: u32,
+    recorded_start_time_us: u64,
+    pub lines_processed: usize,
+    pub lines_skipped: usize,
+    pub log: Option<&'a slog::Logger>,
+
+    capture_locations_monotonic: CaptureLocations,
+    htyp: u8, // std hdr htyp
+    len_wo_payload: u16,
+    tag_apid_map: HashMap<String, DltChar4>,
+    ecu: DltChar4,
+    ctid: DltChar4,
+}
+
+impl<'a, R: BufRead> LogCat2DltMsgIterator<'a, R> {
+    pub fn new(
+        start_index: DltMessageIndexType,
+        reader: R,
+        namespace: u32,
+        _timestamp_reference_time_us: Option<u64>,
+        file_modified_time_us: Option<u64>,
+        log: Option<&'a slog::Logger>,
+    ) -> LogCat2DltMsgIterator<'a, R> {
+        let htyp = DLT_STD_HDR_VERSION
+            | DLT_STD_HDR_HAS_ECU_ID
+            | DLT_STD_HDR_HAS_TIMESTAMP
+            | DLT_STD_HDR_HAS_EXT_HDR
+            | if 1u32.to_be() == 1u32 {
+                DLT_STD_HDR_BIG_ENDIAN
+            } else {
+                0u8
+            };
+        let len_wo_payload = (DLT_MIN_STD_HEADER_SIZE + 4 + 4 + DLT_EXT_HEADER_SIZE) as u16;
+        println!(
+            "LogCat2DltMsgIterator: file_modified_time_us {:?}",
+            file_modified_time_us.map(utc_time_from_us)
+        );
+        if let Some(log) = log {
+            warn!(
+                log,
+                "LogCat2DltMsgIterator: file_modified_time_us {:?}",
+                file_modified_time_us.map(utc_time_from_us)
+            )
+        }
+
+        LogCat2DltMsgIterator {
+            lines: reader.lines(),
+            index: start_index,
+            namespace,
+            recorded_start_time_us: file_modified_time_us
+                .unwrap_or_else(|| (chrono::Utc::now().naive_utc().timestamp_micros()) as u64),
+            lines_processed: 0,
+            lines_skipped: 0,
+            log,
+            capture_locations_monotonic: RE_MONOTONIC.capture_locations(),
+            htyp,
+            len_wo_payload,
+            tag_apid_map: HashMap::new(),
+            ecu: DltChar4::from_str(format!("LC{:02}", namespace % 100).as_str()).unwrap(),
+            ctid: DltChar4::from_str("LogC").unwrap(),
+        }
+    }
+
+    fn get_apid(&mut self, tag: &str) -> DltChar4 {
+        let e = self.tag_apid_map.get(tag);
+        match e {
+            Some(e) => e.to_owned(),
+            None => {
+                let apid = get_apid_for_tag(self.namespace, tag);
+                self.tag_apid_map.insert(tag.to_owned(), apid.to_owned());
+                apid
+            }
+        }
+    }
+
+    fn timestamp_dms_from(&self, timestamp_us: u64) -> u32 {
+        (timestamp_us / 100) as u32
+    }
+}
+
+fn get_4digit_str(a_str: &str, iteration: u16) -> Cow<'_, str> {
+    match iteration {
+        0 => Cow::from(a_str),
+        _ => {
+            let len_str = a_str.len();
+            let number_str = iteration.to_string();
+            let len_number = number_str.len();
+            let needed_str = if len_number > 3 { 0 } else { 4 - len_number };
+            if needed_str > len_str {
+                Cow::Owned(format!("{}{:0len$}", a_str, iteration, len = 4 - len_str))
+            } else {
+                Cow::Owned(format!("{}{}", &a_str[0..needed_str], iteration))
+            }
+        }
+    }
+}
+
+fn get_apid_for_tag(namespace: u32, tag: &str) -> DltChar4 {
+    let mut namespace_map = GLOBAL_TAG_APID_MAP.write().unwrap();
+    let map = namespace_map.entry(namespace).or_insert_with(HashMap::new);
+    match map.get(tag) {
+        Some(e) => e.to_owned(),
+        None => {
+            let trimmed_tag = tag.trim();
+            // try to find a good apid as tag abbrevation
+            //
+            let mut iteration = 0u16;
+            loop {
+                let apid = match trimmed_tag.len() {
+                    0 => DltChar4::from_str(" ").unwrap(),
+                    1 | 2 | 3 | 4 => DltChar4::from_str(&get_4digit_str(trimmed_tag, iteration))
+                        .unwrap_or(DltChar4::from_str(&get_4digit_str("NoAs", iteration)).unwrap()),
+                    _ => {
+                        let has_underscores = trimmed_tag.contains('_');
+                        if has_underscores {
+                            // assume snake case
+                            let nr_underscore = trimmed_tag.chars().fold(0u32, |acc, c| {
+                                if c == '_' {
+                                    acc + 1
+                                } else {
+                                    acc
+                                }
+                            });
+                            let mut needed_other = if nr_underscore < 3 {
+                                3 - nr_underscore
+                            } else {
+                                0
+                            };
+                            let mut abbrev = String::with_capacity(4);
+                            let mut take_next = true;
+                            for c in trimmed_tag.chars() {
+                                if c == '_' {
+                                    take_next = true;
+                                } else if c.is_ascii() {
+                                    if take_next || needed_other > 0 {
+                                        abbrev.push(c);
+                                        if !take_next {
+                                            needed_other -= 1;
+                                        }
+                                    }
+                                    take_next = false;
+                                }
+                                if abbrev.len() >= 4 {
+                                    break;
+                                }
+                            }
+
+                            DltChar4::from_str(&get_4digit_str(&abbrev, iteration))
+                        } else {
+                            // assume camel case
+                            let nr_capital = trimmed_tag.chars().fold(0u32, |acc, c| {
+                                if c.is_ascii_uppercase() {
+                                    acc + 1
+                                } else {
+                                    acc
+                                }
+                            });
+                            let mut needed_lowercase =
+                                if nr_capital < 4 { 4 - nr_capital } else { 0 };
+                            let mut abbrev = String::with_capacity(4);
+                            for c in trimmed_tag.chars() {
+                                if c.is_ascii_uppercase() {
+                                    abbrev.push(c);
+                                } else if needed_lowercase > 0 && c.is_ascii() {
+                                    abbrev.push(c);
+                                    needed_lowercase -= 1;
+                                }
+                                if abbrev.len() >= 4 {
+                                    break;
+                                }
+                            }
+
+                            DltChar4::from_str(&get_4digit_str(&abbrev, iteration))
+                        }
+                    }
+                    .unwrap_or(DltChar4::from_str(&get_4digit_str("NoAs", iteration)).unwrap()),
+                };
+
+                // does apid exist already?
+                if let Some((_k, _v)) = map.iter().find(|(_k, v)| v == &&apid) {
+                    /* println!(
+                        "get_apid_for_tag iteration {} apid {} for tag {} exists already for tag {}",
+                        iteration, apid, tag, k
+                    ); */
+                    iteration += 1;
+                } else {
+                    map.insert(tag.to_owned(), apid.to_owned());
+                    return apid;
+                }
+            } // todo abort after >100 iterations with a default?
+        }
+    }
+}
+
+/// Parse a timestamp in logcat monotonic format to a time in us.
+///
+/// Expected format is x.y (x any number, y any number but expected 3 digits)
+///
+/// In case of any parsing errors 0 is returned.
+/// ### Note
+/// The function is slow if the the fraction is not 3 digits!
+fn parse_time_str(timestamp: &str) -> u64 {
+    let dot_idx = timestamp.find('.').unwrap_or(timestamp.len());
+
+    let timestamp_secs_us: u64 =
+        timestamp[0..dot_idx].parse::<u64>().unwrap_or_default() * US_PER_SEC;
+
+    let timestamp_fraction_us = if dot_idx < timestamp.len() {
+        let timestamp_fraction_str = &timestamp[dot_idx + 1..];
+        let mut len_fraction = timestamp_fraction_str.len();
+        let mut timestamp_fraction_us = timestamp_fraction_str.parse::<u64>().unwrap_or_default();
+        if len_fraction == 3 {
+            // expected len
+            timestamp_fraction_us *= 1000;
+        } else if len_fraction != 6 {
+            while len_fraction < 6 {
+                timestamp_fraction_us *= 10;
+                len_fraction += 1;
+            }
+            while len_fraction > 6 {
+                timestamp_fraction_us /= 10;
+                len_fraction -= 1;
+            }
+        }
+        timestamp_fraction_us
+    } else {
+        0
+    };
+    timestamp_secs_us + timestamp_fraction_us
+}
+
+lazy_static! {
+    pub(crate) static ref RE_MONOTONIC: Regex =
+        Regex::new(r"^\s*(\d+\.\d+)\s+(\d+)\s+(\d+) ([A-Za-z]) (.*?)\s*: (.*)$").unwrap();
+        // captures: monotonic_timestamp pid tid level tag msg
+
+    // map by namespace to a map for tag to apid:
+    static ref GLOBAL_TAG_APID_MAP: RwLock<HashMap<u32, HashMap<String, DltChar4>>> = RwLock::new(HashMap::new());
+
+}
+
+impl<'a, R> Iterator for LogCat2DltMsgIterator<'a, R>
+where
+    R: BufRead,
+{
+    type Item = DltMessage;
+    fn next(&mut self) -> Option<Self::Item> {
+        for line in self.lines.by_ref() {
+            self.lines_processed += 1;
+            match &line {
+                Ok(line) => {
+                    if let Some(captures) =
+                        RE_MONOTONIC.captures_read(&mut self.capture_locations_monotonic, line)
+                    {
+                        let cap_str = captures.as_str();
+                        let loc_timestamp = self.capture_locations_monotonic.get(1).unwrap();
+                        let timestamp_us =
+                            parse_time_str(&cap_str[loc_timestamp.0..loc_timestamp.1]);
+
+                        let loc_level = self.capture_locations_monotonic.get(4).unwrap();
+                        let log_level = match &cap_str[loc_level.0..loc_level.1].as_bytes()[0] {
+                            b'I' => DltMessageLogType::Info,
+                            b'W' => DltMessageLogType::Warn,
+                            b'E' => DltMessageLogType::Error,
+                            b'V' => DltMessageLogType::Verbose,
+                            b'F' | b'S' => DltMessageLogType::Fatal,
+                            _ => DltMessageLogType::Debug,
+                        };
+
+                        // let loc_pid = self.capture_locations_monotonic.get(2).unwrap();
+
+                        let loc_tag = self.capture_locations_monotonic.get(5).unwrap();
+                        let tag = &cap_str[loc_tag.0..loc_tag.1];
+
+                        let index = self.index;
+                        self.index += 1;
+                        let payload = vec![];
+
+                        let apid = self.get_apid(tag);
+                        let mtin: u8 = log_level as u8;
+                        return Some(DltMessage {
+                            index,
+                            reception_time_us: self.recorded_start_time_us + timestamp_us, // should be from last... (but we'd need to scan all)
+                            ecu: self.ecu.to_owned(),
+                            timestamp_dms: self.timestamp_dms_from(timestamp_us),
+                            standard_header: DltStandardHeader {
+                                htyp: self.htyp,
+                                mcnt: (index & 0xff) as u8,
+                                len: self.len_wo_payload + (payload.len() as u16),
+                            },
+                            extended_header: Some(DltExtendedHeader {
+                                verb_mstp_mtin: (1u8 << 0) /* | (0u8 << 1)*/ | (mtin << 4), // verb, log,
+                                noar: 0,
+                                apid,
+                                ctid: self.ctid.to_owned(),
+                            }),
+                            payload,
+                            payload_text: Some(cap_str[loc_timestamp.1 + 1..].to_owned()),
+                            lifecycle: 0,
+                        });
+                    } else if !line.is_empty() {
+                        self.lines_skipped += 1;
+                        if let Some(log) = self.log {
+                            debug!(
+                                log,
+                                "LogCat2DltMsgIterator.next unknown line {} at line #{}",
+                                line,
+                                self.lines_processed
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    if let Some(log) = self.log {
+                        error!(
+                            log,
+                            "LogCat2DltMsgIterator.next got err {} at line #{}",
+                            e,
+                            self.lines_processed
+                        );
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{dlt::DltChar4, utils::US_PER_SEC};
+
+    use super::{get_4digit_str, get_apid_for_tag, parse_time_str};
+
+    const MS_PER_SEC: u64 = 1000;
+
+    #[test]
+    fn parse_time_str_1() {
+        assert_eq!(parse_time_str("19.002"), 19 * US_PER_SEC + 2 * MS_PER_SEC);
+        assert_eq!(parse_time_str("0.999"), 999 * MS_PER_SEC);
+    }
+
+    #[test]
+    fn get_4digit_str_1() {
+        assert_eq!(get_4digit_str("", 0), "");
+        assert_eq!(get_4digit_str("", 1), "0001");
+        assert_eq!(get_4digit_str("a", 0), "a");
+        assert_eq!(get_4digit_str("a", 1), "a001");
+        assert_eq!(get_4digit_str("a", 99), "a099");
+        assert_eq!(get_4digit_str("a", 1000), "1000");
+        assert_eq!(get_4digit_str("abc", 9), "abc9");
+        assert_eq!(get_4digit_str("abc", 99), "ab99");
+        assert_eq!(get_4digit_str("abcd", 0), "abcd");
+        assert_eq!(get_4digit_str("abcd", 1), "abc1");
+        assert_eq!(get_4digit_str("abcd", 9), "abc9");
+        assert_eq!(get_4digit_str("abcd", 10), "ab10");
+        assert_eq!(get_4digit_str("abcd", 99), "ab99");
+        assert_eq!(get_4digit_str("abcd", 100), "a100");
+        assert_eq!(get_4digit_str("abcd", 999), "a999");
+        assert_eq!(get_4digit_str("abcd", 1000), "1000");
+    }
+
+    #[test]
+    fn get_apid_for_tag_1() {
+        assert_eq!(
+            get_apid_for_tag(0, "snake_case"),
+            DltChar4::from_buf(b"snac")
+        );
+        assert_eq!(
+            get_apid_for_tag(0, "snake_case2"),
+            DltChar4::from_buf(b"sna1") // snac -> exists -> add numbers...
+        );
+        assert_eq!(
+            get_apid_for_tag(1, "snake_case3"),
+            DltChar4::from_buf(b"snac") // different namespace
+        );
+
+        assert_eq!(
+            get_apid_for_tag(0, "CamelBaseAllGood"),
+            DltChar4::from_buf(b"CBAG")
+        );
+        assert_eq!(
+            get_apid_for_tag(0, "CamelBaseAll"),
+            DltChar4::from_buf(b"CaBA")
+        );
+    }
+}

--- a/src/utils/logcat2dltmsgiterator.rs
+++ b/src/utils/logcat2dltmsgiterator.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use regex::{CaptureLocations, Regex};
-use slog::{debug, error, warn};
+use slog::{debug, error, info};
 /// todos
 /// [] think about a better way to handle multiple files opened. currently they might be wrongly sorted as the timestamp is added as offset
 ///    we'd want the last log from a file to have the recorded time = calculated time
@@ -62,12 +62,8 @@ impl<'a, R: BufRead> LogCat2DltMsgIterator<'a, R> {
                 0u8
             };
         let len_wo_payload = (DLT_MIN_STD_HEADER_SIZE + 4 + 4 + DLT_EXT_HEADER_SIZE) as u16;
-        println!(
-            "LogCat2DltMsgIterator: file_modified_time_us {:?}",
-            file_modified_time_us.map(utc_time_from_us)
-        );
         if let Some(log) = log {
-            warn!(
+            info!(
                 log,
                 "LogCat2DltMsgIterator: file_modified_time_us {:?}",
                 file_modified_time_us.map(utc_time_from_us)

--- a/src/utils/sorting_multi_readeriterator.rs
+++ b/src/utils/sorting_multi_readeriterator.rs
@@ -176,7 +176,8 @@ mod tests {
             512 * 1024usize,
             DLT_MAX_STORAGE_MSG_SIZE,
         );
-        let it1 = get_dlt_message_iterator("asc", 0, buf_reader, get_new_namespace(), None, None);
+        let it1 =
+            get_dlt_message_iterator("asc", 0, buf_reader, get_new_namespace(), None, None, None);
         let mit = SortingMultiReaderIterator::new(0, vec![it1]);
         let mut iterated_msgs = 0;
         for m in mit {
@@ -194,14 +195,14 @@ mod tests {
             DLT_MAX_STORAGE_MSG_SIZE,
         );
         let namespace = get_new_namespace();
-        let it1 = get_dlt_message_iterator("asc", 0, buf_reader1, namespace, None, None);
+        let it1 = get_dlt_message_iterator("asc", 0, buf_reader1, namespace, None, None, None);
 
         let buf_reader2 = LowMarkBufReader::new(
             File::open("./tests/can_example1c.asc").unwrap(),
             512 * 1024usize,
             DLT_MAX_STORAGE_MSG_SIZE,
         );
-        let it2 = get_dlt_message_iterator("asc", 0, buf_reader2, namespace, None, None);
+        let it2 = get_dlt_message_iterator("asc", 0, buf_reader2, namespace, None, None, None);
 
         let mit = SortingMultiReaderIterator::new(0, vec![it2, it1]);
         let mut iterated_msgs = 0;
@@ -226,7 +227,7 @@ mod tests {
                 512 * 1024usize,
                 DLT_MAX_STORAGE_MSG_SIZE,
             );
-            get_dlt_message_iterator("asc", 0, buf_reader, namespace, None, None)
+            get_dlt_message_iterator("asc", 0, buf_reader, namespace, None, None, None)
         });
 
         assert_eq!((1, Some(1)), its.size_hint());
@@ -248,14 +249,14 @@ mod tests {
             DLT_MAX_STORAGE_MSG_SIZE,
         );
         let namespace = get_new_namespace();
-        let it1 = get_dlt_message_iterator("asc", 0, buf_reader1, namespace, None, None);
+        let it1 = get_dlt_message_iterator("asc", 0, buf_reader1, namespace, None, None, None);
 
         let buf_reader2 = LowMarkBufReader::new(
             File::open("./tests/can_example1c.asc").unwrap(),
             512 * 1024usize,
             DLT_MAX_STORAGE_MSG_SIZE,
         );
-        let it2 = get_dlt_message_iterator("asc", 0, buf_reader2, namespace, None, None);
+        let it2 = get_dlt_message_iterator("asc", 0, buf_reader2, namespace, None, None, None);
 
         let mit = SequentialMultiIterator::new(0, vec![it2, it1].into_iter());
         let mut iterated_msgs = 0;
@@ -276,7 +277,7 @@ mod tests {
                 512 * 1024usize,
                 DLT_MAX_STORAGE_MSG_SIZE,
             );
-            get_dlt_message_iterator("asc", 0, buf_reader, namespace, None, None)
+            get_dlt_message_iterator("asc", 0, buf_reader, namespace, None, None, None)
         });
 
         let mit = SequentialMultiIterator::new(0, its);
@@ -309,6 +310,7 @@ mod tests {
                 namespace,
                 first_reception_time_us,
                 None,
+                None,
             )
         });
         let mit_2a = SequentialMultiIterator::new(0, its);
@@ -327,6 +329,7 @@ mod tests {
                 buf_reader,
                 namespace,
                 first_reception_time_us,
+                None,
                 None,
             )
         });
@@ -352,6 +355,7 @@ mod tests {
                 buf_reader,
                 namespace,
                 first_reception_time_us,
+                None,
                 None,
             )
         });

--- a/tests/logcat_example1.txt
+++ b/tests/logcat_example1.txt
@@ -1,0 +1,348 @@
+console:/ # logcat -b all
+logcat -b all
+
+--------- beginning of events
+    18.062   529   529 I auditd  : type=1400 audit(0.0:35): avc: denied { open } for comm="LogManager" path="/data/vdspies/ENC" dev="dm-11" ino=278532 scontext=u:r:logmanager:s0 tcontext=u:object_r:vdspies_dir:s0 tclass=dir permissive=1
+    18.086   529   529 I auditd  : type=1400 audit(0.0:36): avc: denied { create } for comm="LogManager" name="IVI_EUSR_Androidlog" scontext=u:r:logmanager:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1
+    18.090   529   529 I auditd  : type=1400 audit(0.0:37): avc: denied { append } for comm="LogManager" name="IVI_EUSR_Androidlog" dev="dm-11" ino=278570 scontext=u:r:logmanager:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1
+    18.090   529   529 I auditd  : type=1400 audit(0.0:38): avc: denied { open } for comm="LogManager" path="/data/vdspies/LogManager/IVI_EUSR_Androidlog" dev="dm-11" ino=278570 scontext=u:r:logmanager:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1
+    18.090   529   529 I auditd  : type=1400 audit(0.0:39): avc: denied { getattr } for comm="LogManager" path="/data/vdspies/VDDLT" dev="dm-11" ino=278530 scontext=u:r:logmanager:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=dir permissive=1
+    18.090   529   529 I auditd  : type=1400 audit(0.0:40): avc: denied { getattr } for comm="LogManager" path="/data/vdspies/LogManager/IVI_EUSR_Androidlog" dev="dm-11" ino=278570 scontext=u:r:logmanager:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1
+    18.094   529   529 I auditd  : type=1400 audit(0.0:41): avc: denied { write } for comm="LogManager" name="lm.log" dev="dm-11" ino=278534 scontext=u:r:logmanager:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1
+    18.374   675   675 I auditd  : type=1400 audit(0.0:42): avc: denied { dac_read_search } for comm="vendor.atestvendor.h" capability=2 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=capability permissive=1
+    18.542   672   672 I auditd  : type=1400 audit(0.0:43): avc: denied { read } for comm="bsrfupdategatew" name="u:object_r:hwservicemanager_prop:s0" dev="tmpfs" ino=12273 scontext=u:r:bsrfupdategateway:s0 tcontext=u:object_r:hwservicemanager_prop:s0 tclass=file permissive=1
+    18.542   672   672 I auditd  : type=1400 audit(0.0:44): avc: denied { open } for comm="bsrfupdategatew" path="/dev/__properties__/u:object_r:hwservicemanager_prop:s0" dev="tmpfs" ino=12273 scontext=u:r:bsrfupdategateway:s0 tcontext=u:object_r:hwservicemanager_prop:s0 tclass=file permissive=1
+    18.542   672   672 I auditd  : type=1400 audit(0.0:45): avc: denied { getattr } for comm="bsrfupdategatew" path="/dev/__properties__/u:object_r:hwservicemanager_prop:s0" dev="tmpfs" ino=12273 scontext=u:r:bsrfupdategateway:s0 tcontext=u:object_r:hwservicemanager_prop:s0 tclass=file permissive=1
+    18.542   672   672 I auditd  : type=1400 audit(0.0:46): avc: denied { map } for comm="bsrfupdategatew" path="/dev/__properties__/u:object_r:hwservicemanager_prop:s0" dev="tmpfs" ino=12273 scontext=u:r:bsrfupdategateway:s0 tcontext=u:object_r:hwservicemanager_prop:s0 tclass=file permissive=1
+    18.550   672   672 I auditd  : type=1400 audit(0.0:47): avc: denied { call } for comm="bsrfupdategatew" scontext=u:r:bsrfupdategateway:s0 tcontext=u:r:hwservicemanager:s0 tclass=binder permissive=1
+    18.550   675   675 I auditd  : type=1400 audit(0.0:48): avc: denied { read write } for comm="vendor.atestvendor.h" name="gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.550   675   675 I auditd  : type=1400 audit(0.0:49): avc: denied { open } for comm="vendor.atestvendor.h" path="/dev/gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.550   675   675 I auditd  : type=1400 audit(0.0:50): avc: denied { ioctl } for comm="vendor.atestvendor.h" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4700 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.550   675   675 I auditd  : type=1400 audit(0.0:51): avc: denied { map } for comm="vendor.atestvendor.h" path="/dev/gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.554   275   275 I auditd  : type=1400 audit(0.0:52): avc: denied { transfer } for comm="hwservicemanage" scontext=u:r:hwservicemanager:s0 tcontext=u:r:bsrfupdategateway:s0 tclass=binder permissive=1
+    18.558   672   672 I auditd  : type=1400 audit(0.0:53): avc: denied { call } for comm="bsrfupdategatew" scontext=u:r:bsrfupdategateway:s0 tcontext=u:r:earlypersist-hal-1_0d:s0 tclass=binder permissive=1
+    18.614   734   734 I auditd  : type=1400 audit(0.0:54): avc: denied { read } for comm="getprop" name="u:object_r:default_prop:s0" dev="tmpfs" ino=12219 scontext=u:r:vendor_qti_init_shell:s0 tcontext=u:object_r:default_prop:s0 tclass=file permissive=1
+    18.622   734   734 I auditd  : type=1400 audit(0.0:55): avc: denied { open } for comm="getprop" path="/dev/__properties__/u:object_r:default_prop:s0" dev="tmpfs" ino=12219 scontext=u:r:vendor_qti_init_shell:s0 tcontext=u:object_r:default_prop:s0 tclass=file permissive=1
+    18.622   734   734 I auditd  : type=1400 audit(0.0:56): avc: denied { getattr } for comm="getprop" path="/dev/__properties__/u:object_r:default_prop:s0" dev="tmpfs" ino=12219 scontext=u:r:vendor_qti_init_shell:s0 tcontext=u:object_r:default_prop:s0 tclass=file permissive=1
+    18.622   734   734 I auditd  : type=1400 audit(0.0:57): avc: denied { map } for comm="getprop" path="/dev/__properties__/u:object_r:default_prop:s0" dev="tmpfs" ino=12219 scontext=u:r:vendor_qti_init_shell:s0 tcontext=u:object_r:default_prop:s0 tclass=file permissive=1
+    18.554   275   275 I auditd  : avc:  denied  { find } for interface=vendor.atestvendor.hardware.earlypersist::IEarlyPersist sid=u:r:bsrfupdategateway:s0 pid=672 scontext=u:r:bsrfupdategateway:s0 tcontext=u:object_r:atestvendorEarlypersistHwservice:s0 tclass=hwservice_manager permissive=1
+    18.686   240   240 I auditd  : type=1400 audit(0.0:58): avc: denied { setattr } for comm="init" name="/" dev="sda13" ino=2 scontext=u:r:vendor_init:s0 tcontext=u:object_r:mnt_vdmapdata_file:s0 tclass=dir permissive=1
+    18.686   240   240 I auditd  : type=1400 audit(0.0:59): avc: denied { search } for comm="init" name="/" dev="sda13" ino=2 scontext=u:r:vendor_init:s0 tcontext=u:object_r:mnt_vdmapdata_file:s0 tclass=dir permissive=1
+    18.704   275   275 I auditd  : avc:  denied  { find } for interface=android.hardware.automotive.vehicle::IVehicle sid=u:r:hal_emp:s0 pid=675 scontext=u:r:hal_emp:s0 tcontext=u:object_r:hal_vehicle_hwservice:s0 tclass=hwservice_manager permissive=1
+    18.786   750   750 I auditd  : type=1400 audit(0.0:60): avc: denied { ioctl } for comm="ifconfig" path="socket:[31531]" dev="sockfs" ino=31531 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    18.794   675   675 I auditd  : type=1400 audit(0.0:61): avc: denied { read write } for comm="EMPRxThread" name="gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.794   675   675 I auditd  : type=1400 audit(0.0:62): avc: denied { open } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.794   675   675 I auditd  : type=1400 audit(0.0:63): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4700 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.794   675   675 I auditd  : type=1400 audit(0.0:64): avc: denied { map } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:65): avc: denied { search } for comm="vendor.atestvendor.S" name="vdspies" dev="dm-11" ino=278529 scontext=u:r:spyservice:s0 tcontext=u:object_r:vdspies_dir:s0 tclass=dir permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:66): avc: denied { search } for comm="vendor.atestvendor.S" name="VDDLT" dev="dm-11" ino=278530 scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=dir permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:67): avc: denied { write } for comm="vendor.atestvendor.S" name="VDDLT" dev="dm-11" ino=278530 scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=dir permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:68): avc: denied { add_name } for comm="vendor.atestvendor.S" name="dtcinfo.txt" scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=dir permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:69): avc: denied { create } for comm="vendor.atestvendor.S" name="dtcinfo.txt" scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=file permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:70): avc: denied { write } for comm="vendor.atestvendor.S" name="dtcinfo.txt" dev="dm-11" ino=278535 scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=file permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:71): avc: denied { open } for comm="vendor.atestvendor.S" path="/data/vdspies/VDDLT/dtcinfo.txt" dev="dm-11" ino=278535 scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=file permissive=1
+    18.910   518   518 I auditd  : type=1400 audit(0.0:72): avc: denied { getattr } for comm="vendor.atestvendor.S" path="/data/vdspies/VDDLT/dtcinfo.txt" dev="dm-11" ino=278535 scontext=u:r:spyservice:s0 tcontext=u:object_r:vddlt_dir:s0 tclass=file permissive=1
+    19.207   422   422 I boot_progress_preload_start: 19207
+    19.797   520   542 I liblog  : 146
+    19.895   520   542 I liblog  : 126
+    19.950   960   960 I auditd  : type=1400 audit(0.0:73): avc: denied { ioctl } for comm="ifconfig" path="socket:[35219]" dev="sockfs" ino=35219 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    19.954   675   675 I auditd  : type=1400 audit(0.0:74): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4702 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    20.114   520   542 I liblog  : 72
+    20.127   520   542 I liblog  : 3
+    20.129   486   486 I liblog  : 8
+    20.129   520   542 I liblog  : 13
+    20.130   520   542 I liblog  : 1
+    20.130   928   928 I liblog  : 1
+    20.131   520   542 I liblog  : 1
+    20.144   486   486 I liblog  : 53
+    20.994  1029  1029 I auditd  : type=1400 audit(0.0:75): avc: denied { ioctl } for comm="ifconfig" path="socket:[35393]" dev="sockfs" ino=35393 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    20.994   675   675 I auditd  : type=1400 audit(0.0:76): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4702 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    22.046  1064  1064 I auditd  : type=1400 audit(0.0:77): avc: denied { ioctl } for comm="ifconfig" path="socket:[35519]" dev="sockfs" ino=35519 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    22.050   675   675 I auditd  : type=1400 audit(0.0:78): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4702 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    22.093   422   422 I boot_progress_preload_end: 22093
+    22.491  1066  1066 I system_server_start: [1,22478,22478]
+    22.491  1066  1066 I boot_progress_system_run: 22491
+    22.866   909   909 I auditd  : type=1400 audit(0.0:79): avc: denied { quotaget } for comm="Binder:909_1" scontext=u:r:installd:s0 tcontext=u:object_r:mnt_vdswl_file:s0 tclass=filesystem permissive=1
+    22.998   343   343 I auditd  : type=1400 audit(0.0:80): avc: denied { read } for comm="Binder:343_2" name="wakeup2" dev="sysfs" ino=24437 scontext=u:r:system_suspend:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=1
+    22.998   343   343 I auditd  : type=1400 audit(0.0:81): avc: denied { open } for comm="Binder:343_2" path="/sys/devices/platform/soc/a800000.ssusb/dual_role_usb/3-1/wakeup2" dev="sysfs" ino=24437 scontext=u:r:system_suspend:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=1
+    22.998   343   343 I auditd  : type=1400 audit(0.0:82): avc: denied { read } for comm="Binder:343_2" name="event_count" dev="sysfs" ino=24444 scontext=u:r:system_suspend:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
+    22.998   343   343 I auditd  : type=1400 audit(0.0:83): avc: denied { open } for comm="Binder:343_2" path="/sys/devices/platform/soc/a800000.ssusb/dual_role_usb/3-1/wakeup2/event_count" dev="sysfs" ino=24444 scontext=u:r:system_suspend:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
+    22.998   343   343 I auditd  : type=1400 audit(0.0:84): avc: denied { getattr } for comm="Binder:343_2" path="/sys/devices/platform/soc/a800000.ssusb/dual_role_usb/3-1/wakeup2/event_count" dev="sysfs" ino=24444 scontext=u:r:system_suspend:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
+    23.036  1066  1066 I service_manager_stats: [100,28,23035]
+    23.040  1066  1092 I commit_sys_config_file: [batterystats,5]
+    23.044  1066  1092 I commit_sys_config_file: [batterystats,3]
+    23.102   529   529 I auditd  : type=1400 audit(0.0:85): avc: denied { call } for comm="LogManager" scontext=u:r:logmanager:s0 tcontext=u:r:TimeManagerProxy1d:s0 tclass=binder permissive=1
+    23.106  1101  1101 I auditd  : type=1400 audit(0.0:86): avc: denied { ioctl } for comm="ifconfig" path="socket:[35622]" dev="sockfs" ino=35622 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    23.106   675   675 I auditd  : type=1400 audit(0.0:87): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4702 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    23.118  1066  1066 I rescue_note: [0,1,23118]
+    23.181  1066  1066 I boot_progress_pms_start: 23181
+    23.410  1066  1066 I boot_progress_pms_system_scan_start: 23410
+    23.751  1066  1066 I boot_progress_pms_data_scan_start: 23751
+    23.756  1066  1066 I boot_progress_pms_scan_end: 23756
+    23.945  1066  1066 I commit_sys_config_file: [package-user-0,5]
+    23.950  1066  1066 I commit_sys_config_file: [package-user-10,4]
+    23.950  1066  1066 I commit_sys_config_file: [package,75]
+    23.950  1066  1066 I boot_progress_pms_ready: 23950
+    24.050  1066  1066 I am_uid_running: 1000
+    24.058  1066  1066 I am_uid_active: 1000
+    24.202  1126  1126 I auditd  : type=1400 audit(0.0:88): avc: denied { ioctl } for comm="ifconfig" path="socket:[37232]" dev="sockfs" ino=37232 ioctlcmd=0x8914 scontext=u:r:hal_emp:s0 tcontext=u:r:hal_emp:s0 tclass=udp_socket permissive=1
+    24.206   675   675 I auditd  : type=1400 audit(0.0:89): avc: denied { ioctl } for comm="EMPRxThread" path="/dev/gipc8" dev="tmpfs" ino=15654 ioctlcmd=0x4702 scontext=u:r:hal_emp:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
+    24.345  1066  1086 I commit_sys_config_file: [overlays,6]
+    24.638  1066  1086 I commit_sys_config_file: [overlays,6]
+    24.640  1066  1104 I battery_status: [1,1,0,0,]
+    24.650   909   909 I auditd  : type=1400 audit(0.0:90): avc: denied { quotaget } for comm="Binder:909_1" scontext=u:r:installd:s0 tcontext=u:object_r:mnt_vdswl_file:s0 tclass=filesystem permissive=1
+--------- beginning of system
+    24.686  1066  1066 I EntropyMixer: Added HW RNG output to entropy pool
+    24.686  1066  1066 I EntropyMixer: Writing entropy...
+--------- beginning of main
+    24.688  1066  1138 I SchedulingPolicyService: Moving 954 back to group default
+    24.691  1066  1066 I SystemServerTiming: StartAccountManagerService
+    24.691  1066  1066 I SystemServiceManager: Starting com.android.server.accounts.AccountManagerService$Lifecycle
+    24.695  1066  1066 I SystemServerTiming: StartContentService
+    24.695  1066  1066 I SystemServiceManager: Starting com.android.server.content.ContentService$Lifecycle
+    24.696  1066  1066 I SystemServerTiming: InstallSystemProviders
+    24.704   675   719 E EthernetService: EMPTestMode: EMP Test Recv Failed.....
+    24.704   675   719 E EthernetService: EMPTestMode: Invalid Test Mode Data
+    24.704   675   719 E EthernetService: EMPTestMode: Bind vlan2 failed:
+    24.712   486   988 E PAL: SndMonitor: monitorThreadLoop: 162: Open failed snd sysfs node
+    24.714  1066  1066 I system_server: The ClassLoaderContext is a special shared library.
+    24.730   592   760 I VHAL    :  83, 184336, 24730, -159613, 0, 0, 0, 0 
+    24.731  1066  1066 W SettingsState: No settings state /data/system/users/0/settings_config.xml
+    24.741   587   726 I ttp     : 24.723000000,6,0,3,0,0x1e,,0,0,0,0,,,,
+    24.744  1066  1066 I SettingsState: directory info for directory/file /data/system/users/0/settings_config.xml with stacktrace 
+    24.744  1066  1066 I SettingsState: java.lang.Exception
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.logSettingsDirectoryInformation(SettingsState.java:892)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.readStateSyncLocked(SettingsState.java:1011)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.<init>(SettingsState.java:292)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsStateLocked(SettingsProvider.java:2783)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsForUserLocked(SettingsProvider.java:2748)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.peekSettingsStateLocked(SettingsProvider.java:3091)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.getSettingsNamesLocked(SettingsProvider.java:2713)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.syncSsaidTableOnStart(SettingsProvider.java:2695)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.<init>(SettingsProvider.java:2588)
+    24.744  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider.onCreate(SettingsProvider.java:347)
+    24.744  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2388)
+    24.744  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2358)
+    24.744  1066  1066 I SettingsState: 	at android.app.ActivityThread.installProvider(ActivityThread.java:7246)
+    24.744  1066  1066 I SettingsState: 	at android.app.ActivityThread.installContentProviders(ActivityThread.java:6787)
+    24.744  1066  1066 I SettingsState: 	at android.app.ActivityThread.installSystemProviders(ActivityThread.java:7439)
+    24.744  1066  1066 I SettingsState: 	at com.android.server.am.ActivityManagerService.installSystemProviders(ActivityManagerService.java:7910)
+    24.744  1066  1066 I SettingsState: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:1122)
+    24.744  1066  1066 I SettingsState: 	at com.android.server.SystemServer.run(SystemServer.java:598)
+    24.744  1066  1066 I SettingsState: 	at com.android.server.SystemServer.main(SystemServer.java:414)
+    24.744  1066  1066 I SettingsState: 	at java.lang.reflect.Method.invoke(Native Method)
+    24.744  1066  1066 I SettingsState: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+    24.744  1066  1066 I SettingsState: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
+    24.744  1066  1066 I SettingsState: ancestor directory /data/system/users/0 exists
+    24.745  1066  1066 I SettingsState: ancestor directory /data/system/users/0 permissions: r: true w: true x: true
+    24.745  1066  1066 I SettingsState: ancestor's parent directory /data/system/users permissions: r: true w: true x: true
+    24.750  1066  1066 W SettingsState: No settings state /data/system/users/0/settings_ssaid.xml
+    24.751  1066  1066 I SettingsState: directory info for directory/file /data/system/users/0/settings_ssaid.xml with stacktrace 
+    24.751  1066  1066 I SettingsState: java.lang.Exception
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.logSettingsDirectoryInformation(SettingsState.java:892)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.readStateSyncLocked(SettingsState.java:1011)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.<init>(SettingsState.java:292)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsStateLocked(SettingsProvider.java:2783)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsForUserLocked(SettingsProvider.java:2771)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.peekSettingsStateLocked(SettingsProvider.java:3091)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.getSettingsNamesLocked(SettingsProvider.java:2713)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.syncSsaidTableOnStart(SettingsProvider.java:2695)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.<init>(SettingsProvider.java:2588)
+    24.751  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider.onCreate(SettingsProvider.java:347)
+    24.751  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2388)
+    24.751  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2358)
+    24.751  1066  1066 I SettingsState: 	at android.app.ActivityThread.installProvider(ActivityThread.java:7246)
+    24.751  1066  1066 I SettingsState: 	at android.app.ActivityThread.installContentProviders(ActivityThread.java:6787)
+    24.751  1066  1066 I SettingsState: 	at android.app.ActivityThread.installSystemProviders(ActivityThread.java:7439)
+    24.751  1066  1066 I SettingsState: 	at com.android.server.am.ActivityManagerService.installSystemProviders(ActivityManagerService.java:7910)
+    24.751  1066  1066 I SettingsState: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:1122)
+    24.751  1066  1066 I SettingsState: 	at com.android.server.SystemServer.run(SystemServer.java:598)
+    24.751  1066  1066 I SettingsState: 	at com.android.server.SystemServer.main(SystemServer.java:414)
+    24.751  1066  1066 I SettingsState: 	at java.lang.reflect.Method.invoke(Native Method)
+    24.751  1066  1066 I SettingsState: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+    24.751  1066  1066 I SettingsState: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
+    24.751  1066  1066 I SettingsState: ancestor directory /data/system/users/0 exists
+    24.751  1066  1066 I SettingsState: ancestor directory /data/system/users/0 permissions: r: true w: true x: true
+    24.751  1066  1066 I SettingsState: ancestor's parent directory /data/system/users permissions: r: true w: true x: true
+    24.762  1066  1066 W SettingsState: No settings state /data/system/users/10/settings_ssaid.xml
+    24.762  1066  1066 I SettingsState: directory info for directory/file /data/system/users/10/settings_ssaid.xml with stacktrace 
+    24.762  1066  1066 I SettingsState: java.lang.Exception
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.logSettingsDirectoryInformation(SettingsState.java:892)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.readStateSyncLocked(SettingsState.java:1011)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsState.<init>(SettingsState.java:292)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsStateLocked(SettingsProvider.java:2783)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsForUserLocked(SettingsProvider.java:2771)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.peekSettingsStateLocked(SettingsProvider.java:3091)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.getSettingsNamesLocked(SettingsProvider.java:2713)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.syncSsaidTableOnStart(SettingsProvider.java:2695)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.<init>(SettingsProvider.java:2588)
+    24.762  1066  1066 I SettingsState: 	at com.android.providers.settings.SettingsProvider.onCreate(SettingsProvider.java:347)
+    24.762  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2388)
+    24.762  1066  1066 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2358)
+    24.762  1066  1066 I SettingsState: 	at android.app.ActivityThread.installProvider(ActivityThread.java:7246)
+    24.762  1066  1066 I SettingsState: 	at android.app.ActivityThread.installContentProviders(ActivityThread.java:6787)
+    24.762  1066  1066 I SettingsState: 	at android.app.ActivityThread.installSystemProviders(ActivityThread.java:7439)
+    24.762  1066  1066 I SettingsState: 	at com.android.server.am.ActivityManagerService.installSystemProviders(ActivityManagerService.java:7910)
+    24.762  1066  1066 I SettingsState: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:1122)
+    24.762  1066  1066 I SettingsState: 	at com.android.server.SystemServer.run(SystemServer.java:598)
+    24.762  1066  1066 I SettingsState: 	at com.android.server.SystemServer.main(SystemServer.java:414)
+    24.762  1066  1066 I SettingsState: 	at java.lang.reflect.Method.invoke(Native Method)
+    24.762  1066  1066 I SettingsState: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+    24.762  1066  1066 I SettingsState: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
+    24.763  1066  1066 I SettingsState: ancestor directory /data/system/users/10 exists
+    24.763  1066  1066 I SettingsState: ancestor directory /data/system/users/10 permissions: r: true w: true x: true
+    24.763  1066  1066 I SettingsState: ancestor's parent directory /data/system/users permissions: r: true w: true x: true
+    24.771   675   742 I EthernetService: EMPTransport: Parse_EMP_Rx_Packet
+    24.772   675   742 I EthernetService: EMPTransport: S_ID M_ID Length : 0x0002 0x003c 0x00000045
+    24.772   675   742 I EthernetService: EMPTransport: S_ID M_ID Length : 0x0000 0x0000 0x00000000
+    24.774  1066  1066 I SystemServerTiming: StartDropBoxManager
+    24.774  1066  1066 I SystemServiceManager: Starting com.android.server.DropBoxManagerService
+    24.775  1066  1066 I SystemServerTiming: StartVibratorService
+    24.775   274   274 E servicemanager: Could not find android.hardware.vibrator.IVibrator/default in the VINTF manifest.
+    24.776   275   275 I hwservicemanager: getTransport: Cannot find entry android.hardware.vibrator@1.0::IVibrator/default in either framework or device manifest.
+    24.777  1066  1066 E VibratorService: vibratorOff command failed (1).
+    24.777   275   275 I hwservicemanager: getTransport: Cannot find entry android.hardware.vibrator@1.3::IVibrator/default in either framework or device manifest.
+    24.779  1066  1066 I SystemServerTiming: StartDynamicSystemService
+    24.780  1066  1066 I SystemServerTiming: StartConsumerIrService
+    24.781   275   275 I hwservicemanager: getTransport: Cannot find entry android.hardware.ir@1.0::IConsumerIr/default in either framework or device manifest.
+    24.782  1066  1066 I SystemServerTiming: StartAlarmManagerService
+    24.782  1066  1066 W AlarmManagerService: no wall clock RTC found
+    24.783   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.783   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.783   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.783   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.783   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.783   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.783   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.783   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.786   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.786   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.786   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.786   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.786   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.786   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.786   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.786   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.787   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.787   529   613 I LMHAL   : in reset head_ 0 tail_ 0 full_ 0 
+    24.787   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.788   529   613 I LMHAL   :  RF is   size 7396
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.788   529   613 I LMHAL   :  buffer is full can't write
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.788   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.788   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.789   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.789   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.789   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.789  1066  1066 I AlarmManager: Current time only 24789, advancing to build time 1688321763000
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.789  1066  1066 W AlarmManagerService: Unable to set rtc to 1688321763: No such device
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.789   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.790   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.790  1066  1066 E HistoricalRegistry: Interaction before persistence initialized
+    24.790   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.791  1066  1066 I SystemServerTiming: StartInputManagerService
+    24.796  1066  1066 I InputManager: Initializing input manager, mUseDevInputEventForAudioJack=true
+    24.797   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.797   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.798   583   640 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.798   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.799   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.799   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.799   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.803   529   613 I LMHAL   : in reset head_ 0 tail_ 0 full_ 0 
+    24.803   529   613 I LMHAL   :  RF is   size 6879
+    24.803   529   613 I LMHAL   :  buffer is full can't write
+    24.803   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.803   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.803   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.803   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.804  1066  1066 I SystemServerTiming: StartWindowManagerService
+    24.804   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'dual_role_usb' not found
+    24.804   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'OVER_CURRENT_PORT' not found
+    24.804   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'UNRECOGNIZED_USB_DEVICE_ON_PORT' not found
+    24.804   576   654 E NetlinkEvent: NetlinkEvent::FindParam(): Parameter 'DWC3_CNTLR_ERR_EVNT_RCVD_ON' not found
+    24.810   592   760 I VHAL    :  84, 184416, 24810, -159613, 0, 0, 0, 0 
+    24.821   587   726 I ttp     : 24.803000000,6,0,3,0,0x1e,,0,0,0,0,,,,
+    24.826  1066  1087 I WindowTracing: Setting window tracing log level to 1
+    24.826  1066  1087 I WindowTracing: Setting window tracing buffer capacity to 2097152bytes
+    24.838  1066  1066 I SystemServerTiming: SetWindowManagerService
+    24.839  1066  1086 I DropBoxManagerService: add tag=system_server_strictmode isTagEnabled=true flags=0x2
+    24.851   669   669 I SurfaceFlinger: isAnimationEnabled value:0
+    24.862   586   607 I VPS     : heart beat received
+    24.862   586   607 I VPS     : pm active cockpit key on
+    24.863   586   607 I VPS     : currPower is same as newPowerMode,not sending
+    24.868   669   669 I SurfaceFlinger: isAnimationEnabled value:0
+    24.871   675   742 I EthernetService: EMPTransport: Parse_EMP_Rx_Packet
+    24.871   675   742 I EthernetService: EMPTransport: S_ID M_ID Length : 0x0002 0x003c 0x00000045
+    24.871   675   742 I EthernetService: EMPTransport: S_ID M_ID Length : 0x0000 0x0000 0x00000000
+    24.872  1142  1142 I android.hardware.camera.provider@2.4-service: CameraProvider@2.4 legacy service is starting.
+    24.875   522   545 I bsrf_wifi_adapter: vendor/atestvendor/hardware/BsrfWifi/1.0/default/bsrf_wifi_adapter/src/core/LwsClient.cpp:pollEvents:412 =>Polling for Lws events
+    24.885   669   669 I SurfaceFlinger: isAnimationEnabled value:0
+    24.889   423   423 E ActivityRecognitionHardware: activity_recognition HAL is deprecated. class_init is effectively a no-op
+    24.890   592   760 I VHAL    :  85, 184496, 24890, -159613, 0, 0, 0, 0 
+    24.890  1142  1142 E CamPrvdr@2.4-legacy: Could not load camera HAL module: -2 (No such file or directory)
+    24.890  1142  1142 E android.hardware.camera.provider@2.4-service: getProviderImpl: camera provider init failed!
+    24.891  1142  1142 W RefBase : CallStack::getCurrentInternal not linked, returning null
+    24.891  1142  1142 W RefBase : CallStack::logStackInternal not linked
+    24.878  1066  1086 I chatty  : uid=1000(system) android.io identical 4 lines
+    24.882  1066  1086 I DropBoxManagerService: add tag=system_server_strictmode isTagEnabled=true flags=0x2
+    24.894  1066  1066 I ActivityTaskManager: Loaded persisted task ids for user 0
+    24.894  1066  1066 I wm_task_created: [1,-1]
+    24.894  1066  1066 I wm_stack_created: 1
+    24.897  1142  1142 E LegacySupport: Could not get passthrough implementation for android.hardware.camera.provider@2.4::ICameraProvider/legacy/0.
+    24.901  1066  1066 I SystemServerTiming: WindowManagerServiceOnInitReady
+    24.901   587   726 I ttp     : 24.883000000,6,0,3,0,0x1e,,0,0,0,0,,,,
+    24.902   669   669 I SurfaceFlinger: isAnimationEnabled value:0
+    24.902  1066  1085 I dvm_lock_sample: [system_server,1,android.ui,54,ActivityManagerService.java,6820,java.lang.String com.android.server.am.ActivityManagerService.checkContentProviderAccess(java.lang.String, int),-,2174,void com.android.server.am.ActivityManagerService.setWindowManager(com.android.server.wm.WindowManagerService),10]
+    24.903   521   553 I bsrf_sms_adapter: vendor/atestvendor/hardware/BsrfSms/1.0/default/bsrf_sms_adapter/src/core/LwsClient.cpp:pollEvents:412 =>Polling for Lws events
+    24.911  1066  1066 I SystemServerTiming: StartInputManager
+    24.911  1066  1066 I InputManager: Starting input manager
+    24.912  1066  1143 I SystemServerTimingAsync: InitThreadPoolExec:StartHidlServices
+    24.912  1066  1143 I SystemServerTimingAsync: StartHidlServices
+    24.912  1066  1066 I InputManager: Enabling motion classifier because just booted: feature enabled, long press timeout = 400
+    24.912  1066  1066 I InputClassifier: Enabling motion classifier
+    24.913  1066  1066 I SystemServerTiming: DisplayManagerWindowManagerAndInputReady
+    24.913  1066  1066 I SystemServerTiming: StartBluetoothService
+    24.913  1066  1066 I SystemServiceManager: Starting com.android.server.BluetoothService
+    24.914  1066  1143 I HidlServiceManagement: Registered android.frameworks.sensorservice@1.0::ISensorManager/default
+    24.915   275   275 I hwservicemanager: getTransport: Cannot find entry android.hardware.input.classifier@1.0::IInputClassifier/default in either framework or device manifest.
+    24.916  1066  1146 I InputClassifier: Could not obtain InputClassifier HAL
+    24.917  1066  1066 I KPI_Marker: [24.917000] [BluetoothManagerService] [PERF_SRV_START] StartBluetoothService


### PR DESCRIPTION
Experimental/first support for:
Logcat files stored with default settings (monotonic timestamp) can be opened as dlt files.
Assumptions:
- stored with extension .txt
- monotonic format
- ecu id is defined as "LCxy" with xy being an increasing number
- apid is based on an abbrevation of the tag
- ctid is fixed as "LogC"
- pid and tid and part of the log message.