### PR TITLE
feat: support regex for ecu, apid, ctid

### DIFF
--- a/benches/filter_benches.rs
+++ b/benches/filter_benches.rs
@@ -154,12 +154,76 @@ pub fn filter_payload_regex_ci(c: &mut Criterion) {
     });
 }
 
+pub fn filter_ecu(c: &mut Criterion) {
+    c.bench_function("filter_ecu", |b| {
+        let v = hex_to_bytes("3d 0a 00 af 45 43 55 31 00 00 03 48 00 75 7d 16 41 08 4c 52 4d 46 55 44 53 00 00 82 00 00 1c 00 46 69 6e 61 6c 20 61 6e 73 77 65 72 20 61 72 72 69 76 65 64 20 61 66 74 65 72 20 00 23 00 00 00 93 01 00 00 00 82 00 00 21 00 75 73 20 66 72 6f 6d 20 74 68 65 20 6a 6f 62 20 68 61 6e 64 6c 65 72 20 5b 73 74 61 74 65 3a 20 00 00 82 00 00 0a 00 41 6e 73 77 65 72 69 6e 67 00 00 82 00 00 0b 00 2c 20 61 6e 73 77 65 72 3a 20 00 10 00 00 00 01 00 82 00 00 10 00 5d 20 66 6f 72 20 72 65 71 75 65 73 74 20 23 00 43 00 00 00 dc 05 00 00").unwrap();
+        let sh = DltStorageHeader {
+            secs: 0,
+            micros: 0,
+            ecu: DltChar4::from_buf(b"ECU1"),
+        };
+        let stdh = DltStandardHeader::from_buf(&v).unwrap();
+        let payload_offset = stdh.std_ext_header_size() as usize;
+        let m = DltMessage::from_headers(
+            1423084,
+            sh,
+            stdh,
+            &v[DLT_MIN_STD_HEADER_SIZE..payload_offset],
+            v[payload_offset..].to_vec(),
+        );
+        let f_a_non =
+                Filter::from_json(r#"{"type": 0, "ecu":"ECU1"}"#)
+                    .unwrap();
+            assert!(f_a_non.ecu.is_some());
+        let f_a_non2 =
+            Filter::from_json(r#"{"type": 0, "ecu":"ECU"}"#)
+                .unwrap();
+            assert!(f_a_non2.ecu.is_some());
+
+        b.iter(|| { // 6ns before regex support
+            assert!(f_a_non.matches(&m), "{:?} != {:?}",m.ecu, f_a_non.ecu);
+            assert!(!f_a_non2.matches(&m));
+        })
+    });
+    c.bench_function("filter_ecu_regex", |b| {
+        let v = hex_to_bytes("3d 0a 00 af 45 43 55 31 00 00 03 48 00 75 7d 16 41 08 4c 52 4d 46 55 44 53 00 00 82 00 00 1c 00 46 69 6e 61 6c 20 61 6e 73 77 65 72 20 61 72 72 69 76 65 64 20 61 66 74 65 72 20 00 23 00 00 00 93 01 00 00 00 82 00 00 21 00 75 73 20 66 72 6f 6d 20 74 68 65 20 6a 6f 62 20 68 61 6e 64 6c 65 72 20 5b 73 74 61 74 65 3a 20 00 00 82 00 00 0a 00 41 6e 73 77 65 72 69 6e 67 00 00 82 00 00 0b 00 2c 20 61 6e 73 77 65 72 3a 20 00 10 00 00 00 01 00 82 00 00 10 00 5d 20 66 6f 72 20 72 65 71 75 65 73 74 20 23 00 43 00 00 00 dc 05 00 00").unwrap();
+        let sh = DltStorageHeader {
+            secs: 0,
+            micros: 0,
+            ecu: DltChar4::from_buf(b"ECU1"),
+        };
+        let stdh = DltStandardHeader::from_buf(&v).unwrap();
+        let payload_offset = stdh.std_ext_header_size() as usize;
+        let m = DltMessage::from_headers(
+            1423084,
+            sh,
+            stdh,
+            &v[DLT_MIN_STD_HEADER_SIZE..payload_offset],
+            v[payload_offset..].to_vec(),
+        );
+        let f_a_non =
+                Filter::from_json(r#"{"type": 0, "ecu":"ECU2|ECU1"}"#)
+                    .unwrap();
+            assert!(f_a_non.ecu.is_some());
+        let f_a_non2 =
+            Filter::from_json(r#"{"type": 0, "ecu":"ECU$"}"#)
+                .unwrap();
+            assert!(f_a_non2.ecu.is_some());
+
+        b.iter(|| { // 6ns before regex support, 6.5ns with ecu, apid, ctid regex support
+            assert!(f_a_non.matches(&m), "{:?} != {:?}",m.ecu, f_a_non.ecu);
+            assert!(!f_a_non2.matches(&m));
+        })
+    });
+}
+
 criterion_group!(
     filter_benches,
     filter_from_json,
     filter_payload_cs,
     filter_payload_ci,
     filter_payload_regex_cs,
-    filter_payload_regex_ci
+    filter_payload_regex_ci,
+    filter_ecu
 );
 criterion_main!(filter_benches);

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,4 +1,5 @@
 mod filter_impl;
+pub use self::filter_impl::Char4OrRegex;
 pub use self::filter_impl::Filter;
 pub use self::filter_impl::FilterKind;
 pub use self::filter_impl::FilterKindContainer;

--- a/src/plugins/rewrite.rs
+++ b/src/plugins/rewrite.rs
@@ -227,7 +227,7 @@ impl RewritePlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dlt::DltChar4;
+    use crate::filter::Char4OrRegex;
     use crate::filter::FilterKind;
     use serde_json::json;
 
@@ -238,7 +238,7 @@ mod tests {
         let p = RewriteConfig::from_json(&cfg).unwrap();
         assert!(p.filter.enabled);
         assert_eq!(p.filter.kind, FilterKind::Positive); // default to pos filter
-        assert_eq!(p.filter.apid, Some(DltChar4::from_buf(b"foo\0")));
+        assert_eq!(p.filter.apid, Char4OrRegex::from_buf(b"foo\0").ok());
         assert_eq!(
             p.payload_regex.as_str(),
             Regex::new("^foo").unwrap().as_str()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -181,6 +181,49 @@ pub fn utc_time_from_us(time_us: u64) -> chrono::NaiveDateTime {
     .unwrap_or_else(|| chrono::NaiveDateTime::from_timestamp_opt(0, 0).unwrap())
 }
 
+/// Checks if a string contains any regular expression special characters.
+///
+/// # Arguments
+///
+/// * `s` - A string slice to check for regex special characters.
+///
+/// # Returns
+///
+/// A boolean value indicating whether the string contains any regex special characters ^$*+?()[]{}|.-\=!<,
+///
+/// # Example
+///
+/// ```
+/// use adlt::utils::contains_regex_chars;
+///
+/// let has_special_chars = contains_regex_chars("hello.*");
+/// assert_eq!(has_special_chars, true);
+/// ```
+pub fn contains_regex_chars(s: &str) -> bool {
+    s.contains(|c| {
+        c == '^'
+            || c == '$'
+            || c == '*'
+            || c == '+'
+            || c == '?'
+            || c == '('
+            || c == ')'
+            || c == '['
+            || c == ']'
+            || c == '{'
+            || c == '}'
+            || c == '|'
+            || c == '.'
+            || c == '-'
+            || c == '\\'
+            || c == '='
+            || c == '!'
+            || c == '<'
+            || c == '>'
+            || c == ','
+    })
+}
+
 static U8_HEX_LOW: [u8; 16] = [
     b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd', b'e', b'f',
 ];
@@ -804,6 +847,21 @@ mod tests {
         assert_eq!(utc_time.date().day(), 1);
         assert_eq!(utc_time.date().month(), 1);
         assert_eq!(utc_time.date().year(), 1970);
+    }
+
+    #[test]
+    fn test_contains_regex_chars() {
+        assert!(!contains_regex_chars("ecu"));
+        assert!(contains_regex_chars("ecu.*"));
+        assert!(contains_regex_chars("ecu\\d+"));
+        assert!(contains_regex_chars("ecu1|ecu2"));
+        assert!(!contains_regex_chars("123"));
+        assert!(contains_regex_chars("[]"));
+        assert!(contains_regex_chars("()"));
+        assert!(contains_regex_chars("\\\\"));
+        assert!(contains_regex_chars("!="));
+        assert!(contains_regex_chars("<>"));
+        assert!(contains_regex_chars(","));
     }
 
     #[test]


### PR DESCRIPTION
Add support for regex (non-utf8) for ecu, apid and ctid. Json filter format extended with: ecuIsRegex, apidIsRegex, ctidIsRegex. Autodetection  based on regex special chars if ...isRegex is not provided. Dlt-Viewer filter format support for enableregexp_Appid, enableregexp_Context. Dlt-Viewer filter format does not support regex for ecu. No autodetection for ecu if imported as dlt-viewer filter (dlf) but if imported as json filter.