### PR TITLE
feat(remote): add "fs" command to support full remote use-cases

### DIFF
--- a/src/bin/adlt/convert.rs
+++ b/src/bin/adlt/convert.rs
@@ -117,7 +117,7 @@ pub fn add_subcommand(app: Command) -> Command {
                 Arg::new("anon")
                 .long("anon")
                 .num_args(0)
-                .help("Anonymize the output. Rewrite APID, CTIDs,sw_versiona and payload. Useful only for lifecycle detection tests.")
+                .help("Anonymize the output. Rewrite APID, CTIDs,sw_versions and payload. Useful only for lifecycle detection tests.")
             )
             .arg(
                 Arg::new("file_transfer")


### PR DESCRIPTION
Add command "fs" with sub commands "stat" and "readDirectory" to support remote use-cases where the UI is not on the same machine.