### PR TITLE
fix: avoid accessing all_msgs out of bound

### DIFF
--- a/src/bin/adlt/remote.rs
+++ b/src/bin/adlt/remote.rs
@@ -1486,7 +1486,8 @@ fn process_file_context<T: Read + Write>(
     // in any stream any messages to send?
     let all_msgs_len = fc.all_msgs.len();
     for stream in &mut fc.streams {
-        let last_all_msgs_last_processed_len = stream.all_msgs_last_processed_len;
+        let last_all_msgs_last_processed_len =
+            std::cmp::min(stream.all_msgs_last_processed_len, all_msgs_len); // TODO investigate how this can happen at all!
         process_stream_new_msgs(
             stream,
             last_all_msgs_last_processed_len,


### PR DESCRIPTION
Hotfix to avoid panics. Investigation needed how this situation can occur at all.