### PR TITLE
fix(remote): queries that have been chunked returned wrong len

### DIFF
--- a/src/bin/adlt/remote.rs
+++ b/src/bin/adlt/remote.rs
@@ -1487,7 +1487,7 @@ fn process_file_context<T: Read + Write>(
     let all_msgs_len = fc.all_msgs.len();
     for stream in &mut fc.streams {
         let last_all_msgs_last_processed_len =
-            std::cmp::min(stream.all_msgs_last_processed_len, all_msgs_len); // TODO investigate how this can happen at all!
+            std::cmp::min(stream.all_msgs_last_processed_len, all_msgs_len);
         process_stream_new_msgs(
             stream,
             last_all_msgs_last_processed_len,

--- a/src/utils/remote_utils.rs
+++ b/src/utils/remote_utils.rs
@@ -172,7 +172,8 @@ pub fn process_stream_new_msgs(
 
                 let max_matching = stream.msgs_to_send.end;
                 let mut start_idx = 0;
-                let part_chunk_size = std::cmp::min(max_chunk_size, 64 * 1024); // we use 64k as max chunk size
+                const PART_CHUNK_SIZE: usize = if cfg!(test) { 64 } else { 64 * 1024 };
+                let part_chunk_size = std::cmp::min(max_chunk_size, PART_CHUNK_SIZE); // we use 64k as max chunk size (and are a bit too lazy to modify the test cases for larger!)
                 while stream.filtered_msgs.len() < max_matching && start_idx < max_idx {
                     let nr_wanted = max_matching - stream.filtered_msgs.len();
 
@@ -186,7 +187,7 @@ pub fn process_stream_new_msgs(
                     // if we found more than wanted, we need to ensure that the next search
                     // restarts at the unwanted one...
                     if matching_idxs.len() <= nr_wanted {
-                        stream.all_msgs_last_processed_len = new_offset + max_this_chunk;
+                        stream.all_msgs_last_processed_len = new_msgs_offset + max_this_chunk;
                     } else {
                         // found more than wanted:
                         let first_unwanted = matching_idxs[nr_wanted];


### PR DESCRIPTION
If the queries had been chunked for parallel search within 64k msgs and then found less than wanted after the full search a wrong all_msgs_last_processed_len was returned. The hotfix from 0.55.2 avoided a panic but yielded wrong results then if later one the search window was extended.

Fixed the root cause and adjusted the part chunk size to 64 msgs only so that the existing unit tests find that bug as well.