### PR TITLE
test(fuzz): add first fuzz tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,26 @@ To compare against a saved baseline:
 cargo bench --bench dlt_benches -- --baseline <saved_baseline_name>
 ```
 
+### run fuzz tests
+
+To list all available fuzz tests:
+
+```
+cargo +nightly fuzz list
+```
+
+You do need to have `cargo-fuzz` installed. To install use `cargo install cargo-fuzz`.
+
+To run a fuzz test:
+
+```
+cargo +nightly fuzz <fuzz test name>
+# e.g.
+cargo +nightly fuzz dlt_v1_parse_std
+```
+
+The fuzz test never stop except if they find a problem. If you find any please create an issue for it or directly a PR with a fix.
+
 ### perform a release
 
 ```

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "adlt-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.adlt]
+path = ".."
+
+[[bin]]
+name = "dlt_v1_parse_std"
+path = "fuzz_targets/dlt_v1_parse_std.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "dlt_v1_payload_as_text"
+path = "fuzz_targets/dlt_v1_payload_as_text.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/dlt_v1_parse_std.rs
+++ b/fuzz/fuzz_targets/dlt_v1_parse_std.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+use adlt::dlt::parse_dlt_with_storage_header;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok((_res, msg)) = parse_dlt_with_storage_header(0, data) {
+        let _ = format!("{:?}", msg);
+        let _ = format!("{}{:?}{:?}", msg.ecu, msg.apid(), msg.ctid(),);
+        let _ = msg.payload_as_text();
+    }
+});

--- a/fuzz/fuzz_targets/dlt_v1_payload_as_text.rs
+++ b/fuzz/fuzz_targets/dlt_v1_payload_as_text.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use adlt::dlt::{
+    DltChar4, DltExtendedHeader, DltMessage, DltStandardHeader, DLT_MIN_STD_HEADER_SIZE,
+};
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|data: Vec<u8>| -> Corpus {
+    if data.len() + DLT_MIN_STD_HEADER_SIZE + 4 + 10 > u16::MAX as usize {
+        return Corpus::Reject;
+    }
+    // create a verbose msg with that payload:
+    let msg = DltMessage {
+        index: data.len() as u32,
+        reception_time_us: data.len() as u64,
+        ecu: DltChar4::from_buf(b"ECU1"),
+        timestamp_dms: 42,
+        standard_header: DltStandardHeader {
+            htyp: 0,
+            mcnt: 0,
+            len: (DLT_MIN_STD_HEADER_SIZE + 4 + 10 + data.len()) as u16,
+        },
+        extended_header: Some(DltExtendedHeader {
+            verb_mstp_mtin: 0x01,
+            noar: 1,
+            apid: DltChar4::from_buf(b"APID"),
+            ctid: DltChar4::from_buf(b"CTID"),
+        }),
+        payload: data,
+        payload_text: None,
+        lifecycle: 0,
+    };
+
+    let _ = msg.payload_as_text();
+    Corpus::Keep
+});

--- a/src/plugins/anonymize.rs
+++ b/src/plugins/anonymize.rs
@@ -48,7 +48,11 @@ impl AnonymizePlugin {
 
     fn ecu_anon(&mut self, msg: &mut DltMessage) {
         if self.ecu_map.contains_key(&msg.ecu) {
-            msg.ecu = self.ecu_map.get(&msg.ecu).unwrap().ecu.to_owned();
+            self.ecu_map
+                .get(&msg.ecu)
+                .unwrap()
+                .ecu
+                .clone_into(&mut msg.ecu);
         } else {
             let new_ecu = DltChar4::from_str(format!("E{:03}", self.ecu_map.len() + 1).as_str())
                 .unwrap_or_else(|_| DltChar4::from_buf(b"E99A"));


### PR DESCRIPTION
can be run from cmd line via:
cargo +nightly fuzz run dlt_v1_parse_std
or
cargo +nightly fuzz run dlt_v1_payload_as_text

List fuzz tests via:
cargo +nightly fuzz list