### PR TITLE
feat(remote): one_pass streams

### DIFF
--- a/src/bin/adlt/convert.rs
+++ b/src/bin/adlt/convert.rs
@@ -736,7 +736,7 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                     match output_style {
                         OutputStyle::HeaderOnly => {
                             msg.header_as_text_to_write( &mut writer_screen)?;
-                            writer_screen.write_all(&[b'\n'])?;
+                            writer_screen.write_all(b"\n")?;
                             did_output = true;
                         }
                         OutputStyle::Ascii => {
@@ -746,9 +746,9 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                         }
                         OutputStyle::Hex => {
                             msg.header_as_text_to_write(&mut writer_screen)?;
-                            writer_screen.write_all(&[b' ',b'['])?;
+                            writer_screen.write_all(b" [")?;
                             buf_as_hex_to_io_write(&mut writer_screen, &msg.payload)?;
-                            writer_screen.write_all(&[b']',b'\n'])?;
+                            writer_screen.write_all(b"]\n")?;
                             did_output = true;
                         }
                         _ => {
@@ -861,13 +861,7 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                 error!(log, "plugin_thread join got Err {:?}", s);
                 Vec::new()
             }
-            Ok(s) => {
-                if let Ok(plugins) = s {
-                    plugins
-                } else {
-                    Vec::new()
-                }
-            }
+            Ok(s) => s.unwrap_or_default(),
         }
     } else {
         Vec::new()
@@ -965,11 +959,7 @@ pub fn convert<W: std::io::Write + Send + 'static>(
                         writeln!(
                             writer_screen,
                             " {}",
-                            if let Some(warn) = warning.as_str() {
-                                warn
-                            } else {
-                                "<unknown type of warning!>"
-                            }
+                            warning.as_str().unwrap_or("<unknown type of warning!>")
                         )?;
                     }
                 }

--- a/src/dlt/mod.rs
+++ b/src/dlt/mod.rs
@@ -726,8 +726,11 @@ impl DltMessage {
     /// - standard header
     /// - extended header
     /// - payload
+    ///
     /// Doesn't try to do "atomic" writes, might fail on io errors with partial writes.
+    ///
     /// session_id not supported yet.
+    ///
     /// Payload endian format is taken from the msg.
     pub fn to_write(&self, writer: &mut impl std::io::Write) -> Result<(), std::io::Error> {
         let storage_header = DltStorageHeader::from_msg(self);
@@ -784,9 +787,9 @@ impl DltMessage {
                 }
             }
             if self.is_verbose() {
-                writer.write_all(&[b' ', b'V'])?;
+                writer.write_all(b" V")?;
             } else {
-                writer.write_all(&[b' ', b'N'])?;
+                writer.write_all(b" N")?;
             }
         } else {
             writer.write_all(b"--- --- N -")?;

--- a/src/plugins/export.rs
+++ b/src/plugins/export.rs
@@ -291,7 +291,8 @@ impl ExportPlugin {
     ///
     /// 1. the lci information is from a "matured" lifecycle (i.e. we have seen all (or at least most) messages of it)
     /// 2. we do the check very early for the lc as we determine it from the first messages that have a "not seen yet"
-    /// lifecycle.id.
+    ///    lifecycle.id.
+    ///
     /// So the lc lifecycle the start can move to earlier and the end will grow to later.
     ///  
     fn keep_lifecycle(lci: &LifecycleInfo, ecu: &DltChar4, lc: &Lifecycle) -> bool {

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -80,15 +80,16 @@ type ApplyCommandFn = fn(
 ///
 /// The state consists of a json object (value) with at least the members:
 /// - name: <name of the plugin>
+///
 /// optional:
 /// - treeItems: Array of objects with
 ///  - label:String
 ///  - children -> json objects with similar structure
-///  optional members:
+///    optional members:
 ///  - tooltip:String
 ///  - description:String
 ///  - iconPath:String (see https://code.visualstudio.com/api/references/icons-in-labels#icon-listing)
-///  to ease presentation in a treeview (https://code.visualstudio.com/api/references/vscode-api#TreeItem)
+///    to ease presentation in a treeview (https://code.visualstudio.com/api/references/vscode-api#TreeItem)
 ///
 /// Two other members are used to interact with a plugin:
 /// - apply_command : optional fn that will be called e.g. from remote plugin_cmd. Current use-case: FileTransferPlugin "save"

--- a/src/utils/remote_utils.rs
+++ b/src/utils/remote_utils.rs
@@ -10,6 +10,7 @@ pub struct StreamContext {
     pub id: u32,
     pub is_done: bool,   // stop message is sent
     pub is_stream: bool, // else one-time query
+    pub one_pass: bool,  // supports no window changes, no search,...
     pub binary: bool,
     pub filters_active: bool,
     pub filters: FilterKindContainer<Vec<Filter>>,
@@ -87,7 +88,12 @@ impl StreamContext {
             }
         }
 
-        let binary = match &v["binary"] {
+        let one_pass = *match &v["one_pass"] {
+            serde_json::Value::Bool(b) => b,
+            _ => &false,
+        };
+
+        let binary = *match &v["binary"] {
             serde_json::Value::Bool(b) => b,
             _ => {
                 if is_stream {
@@ -108,7 +114,8 @@ impl StreamContext {
             id: NEXT_STREAM_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             is_done: false,
             is_stream,
-            binary: *binary,
+            one_pass,
+            binary,
             filters,
             filters_active,
             filtered_msgs: Vec::new(),

--- a/src/utils/unzip.rs
+++ b/src/utils/unzip.rs
@@ -53,6 +53,7 @@ use std::{
 /// Two formats are supported:
 ///  - foo.zip/... and
 ///  - foo.zip!/...
+///
 /// The functions does this by checking whether any ancestor the of path does exist.
 /// So it's not a parsing of it but needs a real file on disk.
 ///


### PR DESCRIPTION
Add first support to one pass streams.
The intended use-case is if e.g. a set of queries should be performed on a huge amount of input messages. Currently the full messages would need to be loaded into RAM. With the one_pass_stream feature the queries will be executed during the first read of the messages. Afterwards the messages are not kept in RAM. This reduces the memory need.
fba-cli will use this to perform fishbone analysis on huge input files.