### PR TITLE
feat(receive): add --no_dlt_headers option for serial mode

### DIFF
--- a/src/bin/adlt/receive.rs
+++ b/src/bin/adlt/receive.rs
@@ -117,6 +117,12 @@ pub fn add_subcommand(app: Command) -> Command {
                     .value_parser(clap::value_parser!(u32)),
             )
             .arg(
+                Arg::new("no_dlt_headers")
+                    .long("no_dlt_headers")
+                    .num_args(0)
+                    .help("Record ASCII/UTF8 data as text messages SER/ASC. Usable with serial port recording only. Msgs are split by newlines or by 500ms timeout."),
+            )
+            .arg(
                 Arg::new("port")
                     .short('p')
                     .num_args(1)
@@ -241,6 +247,7 @@ pub fn receive<W: std::io::Write + Send + 'static>(
         None
     };
     let baudrate = sub_m.get_one::<u32>("baudrate");
+    let no_dlt_headers = sub_m.get_flag("no_dlt_headers");
     let port = sub_m.get_one::<u16>("port").unwrap_or(&3490);
     let udp_multicast = sub_m.get_flag("udp_multicast");
     let output_style: OutputStyle = if sub_m.get_flag("hex") {
@@ -264,10 +271,18 @@ pub fn receive<W: std::io::Write + Send + 'static>(
         .get_one::<String>("rewrite_path")
         .map(|s| s.to_owned());
 
+    if no_dlt_headers && baudrate.is_none() {
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--no_dlt_headers can only be used with serial mode (-b/--baudrate)",
+        )));
+    }
+
     let (recv_mode, recv_addr) = if let (Some(baudrate), Some(hostname)) = (baudrate, hostname) {
         let serial_params = SerialParams {
             device_name: hostname.to_owned(),
             baudrate: *baudrate,
+            expect_serial_header: !no_dlt_headers,
         };
         let recv_mode = RecvMode::Serial(serial_params);
         (
@@ -1232,6 +1247,22 @@ mod tests {
             Some(String::from("127.0.0.1"))
         );
         //let r = receive(&logger, sub_m, std::io::stdout());
+    }
+
+    #[test]
+    fn params_no_dlt_headers_requires_serial() {
+        let logger = new_logger();
+        let arg_vec = vec!["t", "receive", "127.0.0.1", "--no_dlt_headers"];
+        let sub_c = add_subcommand(Command::new("t")).get_matches_from(arg_vec);
+        let (_c, sub_m) = sub_c.subcommand().unwrap();
+
+        let result = receive(&logger, sub_m, std::io::sink(), None);
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("--no_dlt_headers can only be used with serial mode"),
+            "unexpected error message: {err_msg}"
+        );
     }
 
     #[test]

--- a/src/bin/adlt/receive.rs
+++ b/src/bin/adlt/receive.rs
@@ -14,6 +14,7 @@ use std::{
     mem::MaybeUninit,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
+    time::{Duration, Instant},
 };
 use thread_priority::{set_current_thread_priority, ThreadPriority};
 
@@ -580,6 +581,8 @@ pub fn receive<W: std::io::Write + Send + 'static>(
         .unwrap();
 
     let mut nr_msg_received = 0usize;
+    let mut last_screen_flush = Instant::now();
+    let flush_interval = Duration::from_millis(500);
     for (msg, _msg_from) in rx_from_forward_thread {
         // verify the consistency of the message TODO for test purposes only. define via parameter!
         nr_msg_received += 1;
@@ -656,7 +659,12 @@ pub fn receive<W: std::io::Write + Send + 'static>(
 
             msg.to_write(file)?;
         }
-        /* TODO how to flush the writer_screen frequently? */
+
+        // Flush writer_screen at least once per 500ms
+        if last_screen_flush.elapsed() >= flush_interval {
+            writer_screen.flush()?;
+            last_screen_flush = Instant::now();
+        }
     }
 
     writer_screen.flush()?;

--- a/src/utils/ipdltmsgreceiver.rs
+++ b/src/utils/ipdltmsgreceiver.rs
@@ -93,6 +93,12 @@ fn parse_dlt_without_header(
     };
 
     let std_hdr_len = DLT_EXT_HEADER_SIZE + 4;
+    let total_len = std_hdr_len + payload.len();
+    let msg_len: u16 = total_len.try_into().map_err(|_| {
+        Error::new(ErrorKind::InvalidData(format!(
+            "message too large: {total_len} bytes exceeds u16::MAX"
+        )))
+    })?;
     let htyp = if cfg!(target_endian = "big") {
         DLT_STD_HDR_VERSION | DLT_STD_HDR_HAS_EXT_HDR | DLT_STD_HDR_BIG_ENDIAN
     } else {
@@ -106,7 +112,7 @@ fn parse_dlt_without_header(
         standard_header: DltStandardHeader {
             htyp,
             mcnt: (index & 0xff) as u8,
-            len: (std_hdr_len + payload.len()).try_into().unwrap_or(u16::MAX),
+            len: msg_len,
         },
         extended_header: Some(DltExtendedHeader {
             verb_mstp_mtin: 0x41, // verbose=1, mstp=0 (Log), mtin=4 (Info)

--- a/src/utils/ipdltmsgreceiver.rs
+++ b/src/utils/ipdltmsgreceiver.rs
@@ -32,8 +32,101 @@ type Ipv4FragmentKey = (Ipv4Addr, Ipv4Addr, IpNextHeaderProtocol, u16);
 
 use crate::dlt::{
     first_idx_of_serial_pattern, parse_dlt_with_serial_header, parse_dlt_with_std_header, DltChar4,
-    DltMessage, DltMessageIndexType, Error, ErrorKind, DLT_SERIAL_HEADER_SIZE,
+    DltExtendedHeader, DltMessage, DltMessageIndexType, DltStandardHeader, Error, ErrorKind,
+    DLT_EXT_HEADER_SIZE, DLT_SERIAL_HEADER_SIZE, DLT_STD_HDR_BIG_ENDIAN, DLT_STD_HDR_HAS_EXT_HDR,
+    DLT_STD_HDR_VERSION,
 };
+
+/// parse a DLT message from the given data as ASCII/UTF-8 text, skipping leading and trailing line separators (\r, \n)
+/// and using the given ECU as storage header ECU.
+///
+/// APID, CTID are set to SER/ASC
+fn parse_dlt_without_header(
+    data: &[u8],
+    index: DltMessageIndexType,
+    storage_header_ecu: DltChar4,
+) -> Result<(usize, DltMessage), Error> {
+    if data.is_empty() {
+        return Err(Error::new(ErrorKind::NotEnoughData(1)));
+    }
+
+    let is_sep = |b: u8| b == b'\r' || b == b'\n';
+
+    let leading_separators = data.iter().take_while(|&&b| is_sep(b)).count();
+    if leading_separators >= data.len() {
+        return Err(Error::new(ErrorKind::InvalidData(
+            "line separators only".to_string(),
+        )));
+    }
+
+    let payload_start = leading_separators;
+    // position() is relative to data[payload_start..], so convert to absolute index in data.
+    let payload_end = data[payload_start..]
+        .iter()
+        .position(|&b| is_sep(b))
+        .map_or(data.len(), |idx| payload_start + idx);
+    let payload = &data[payload_start..payload_end];
+    if payload.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidData(
+            "empty payload".to_string(),
+        )));
+    }
+
+    let now_us = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros() as u64)
+        .unwrap_or(0);
+
+    let payload_text = std::str::from_utf8(payload).ok();
+    let (noar, payload) = if let Some(text) = payload_text {
+        crate::dlt_args!(text).map_err(|e| {
+            Error::new(ErrorKind::InvalidData(format!(
+                "failed to serialize UTF-8 payload as verbose DLT argument: {e}"
+            )))
+        })?
+    } else {
+        crate::dlt_args!(serde_bytes::Bytes::new(payload)).map_err(|e| {
+            Error::new(ErrorKind::InvalidData(format!(
+                "failed to serialize RAW payload as verbose DLT argument: {e}"
+            )))
+        })?
+    };
+
+    let std_hdr_len = DLT_EXT_HEADER_SIZE + 4;
+    let htyp = if cfg!(target_endian = "big") {
+        DLT_STD_HDR_VERSION | DLT_STD_HDR_HAS_EXT_HDR | DLT_STD_HDR_BIG_ENDIAN
+    } else {
+        DLT_STD_HDR_VERSION | DLT_STD_HDR_HAS_EXT_HDR
+    };
+    let msg = DltMessage {
+        index,
+        reception_time_us: now_us,
+        ecu: storage_header_ecu,
+        timestamp_dms: 0,
+        standard_header: DltStandardHeader {
+            htyp,
+            mcnt: (index & 0xff) as u8,
+            len: (std_hdr_len + payload.len()).try_into().unwrap_or(u16::MAX),
+        },
+        extended_header: Some(DltExtendedHeader {
+            verb_mstp_mtin: 1,
+            noar,
+            apid: DltChar4::from_buf(b"SER\0"),
+            ctid: DltChar4::from_buf(b"ASC\0"),
+        }),
+        payload,
+        payload_text: None,
+        lifecycle: 0,
+    };
+
+    let trailing_separators = data[payload_end..]
+        .iter()
+        .take_while(|&&b| is_sep(b))
+        .count();
+    let to_consume = payload_end + trailing_separators;
+
+    Ok((to_consume, msg))
+}
 
 #[cfg(not(windows))]
 fn open_serial_port_from_file(path: &str) -> Result<serial2::SerialPort, std::io::Error> {
@@ -251,6 +344,7 @@ pub enum PcapParam {
 pub struct SerialParams {
     pub device_name: String,
     pub baudrate: u32,
+    pub expect_serial_header: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -298,6 +392,7 @@ impl std::fmt::Display for RecvMode {
 enum ExpectedHeader {
     Serial, // expect DLT_SERIAL_HEADER
     Std,    // expect no header but directly the DLT standard header
+    None,   // expect no DLT header at all
 }
 
 pub struct IpDltMsgReceiver {
@@ -602,7 +697,14 @@ impl IpDltMsgReceiver {
         };
 
         let expected_header = match recv_mode {
-            RecvMode::Serial(_) => ExpectedHeader::Serial,
+            RecvMode::Serial(SerialParams {
+                expect_serial_header: true,
+                ..
+            }) => ExpectedHeader::Serial,
+            RecvMode::Serial(SerialParams {
+                expect_serial_header: false,
+                ..
+            }) => ExpectedHeader::None,
             _ => ExpectedHeader::Std,
         };
 
@@ -888,6 +990,9 @@ impl IpDltMsgReceiver {
                     self.storage_header_ecu,
                     true,
                 ),
+                ExpectedHeader::None => {
+                    parse_dlt_without_header(rem_data, self.index, self.storage_header_ecu)
+                }
             } {
                 Ok((to_consume, msg)) => {
                     debug_assert_eq!(
@@ -896,6 +1001,7 @@ impl IpDltMsgReceiver {
                             ExpectedHeader::Serial => {
                                 (msg.standard_header.len as usize) + DLT_SERIAL_HEADER_SIZE
                             }
+                            ExpectedHeader::None => to_consume, // no check as e.g. sep are skipped
                         },
                         to_consume,
                         "The DLT message length should match the consumed data length"
@@ -932,6 +1038,9 @@ impl IpDltMsgReceiver {
                             .iter()
                             .position(|&b| (((b >> 5) & 0x07) == 1) || (((b >> 5) & 0x07) == 2)),
                         ExpectedHeader::Serial => first_idx_of_serial_pattern(&rem_data[1..]),
+                        ExpectedHeader::None => {
+                            rem_data[1..].iter().position(|&b| b != b'\r' && b != b'\n')
+                        }
                     };
                     if let Some(idx) = idx_first_pos_header {
                         warn!(
@@ -1386,6 +1495,69 @@ mod tests {
         (buf, payload)
     }
 
+    #[test]
+    fn parse_without_header_utf8_strips_line_separators_and_empties() {
+        let input = b"\r\nhello\n\nworld\r\n";
+        let ecu = DltChar4::from_buf(b"EcuS");
+        let mut idx = 100;
+        let mut offset = 0usize;
+        let mut parsed: Vec<DltMessage> = Vec::new();
+
+        while offset < input.len() {
+            match parse_dlt_without_header(&input[offset..], idx, ecu) {
+                Ok((consumed, msg)) => {
+                    offset += consumed;
+                    idx += 1;
+                    parsed.push(msg);
+                }
+                Err(Error {
+                    kind: ErrorKind::NotEnoughData(_),
+                }) => break,
+                Err(_) => {
+                    let rem = &input[offset..];
+                    let consume = rem
+                        .iter()
+                        .take_while(|&&b| b == b'\r' || b == b'\n')
+                        .count()
+                        .max(1);
+                    offset += consume;
+                }
+            }
+        }
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].payload_as_text().as_deref(), Ok("hello"));
+        assert_eq!(parsed[1].payload_as_text().as_deref(), Ok("world"));
+        assert_eq!(
+            parsed[0].apid().map(|a| a.to_string()).as_deref(),
+            Some("SER")
+        );
+        assert_eq!(
+            parsed[0].ctid().map(|c| c.to_string()).as_deref(),
+            Some("ASC")
+        );
+    }
+
+    #[test]
+    fn parse_without_header_raw_bytes_if_not_utf8() {
+        let input = [0xff, 0x80, 0x01, 0x02];
+        let ecu = DltChar4::from_buf(b"EcuS");
+
+        match parse_dlt_without_header(&input, 7, ecu) {
+            Ok((consumed, msg)) => {
+                assert_eq!(consumed, input.len());
+                assert!(msg.payload_text.is_none());
+                assert_eq!(msg.payload_as_text().as_deref(), Ok("ff 80 01 02"));
+                assert_eq!(msg.payload.len(), 4 + 2 + input.len());
+                // check that msg.payload type is indeed RawBytes and contains the original bytes via the dlt arg iterator:
+                let args_iter = msg.into_iter();
+                let arg = args_iter.into_iter().next().unwrap();
+                assert_eq!(arg.type_info, crate::dlt::DLT_TYPE_INFO_RAWD);
+            }
+            _ => panic!("Expected parsed raw-bytes message"),
+        }
+    }
+
     // MARK: serial tests
     #[cfg(not(windows))] // the pipe is blocking (not supporting the timeout) on windows
     #[test]
@@ -1401,6 +1573,7 @@ mod tests {
             recv_mode: RecvMode::Serial(SerialParams {
                 device_name: "test".to_string(),
                 baudrate: 0,
+                expect_serial_header: true,
             }),
             recv_method: RecvMethod::Serial(unsafe { serial2::SerialPort::from_raw_fd(read_fd) }),
             expected_header: ExpectedHeader::Serial,
@@ -1473,6 +1646,7 @@ mod tests {
             recv_mode: RecvMode::Serial(SerialParams {
                 device_name: "test".to_string(),
                 baudrate: 0,
+                expect_serial_header: true,
             }),
             recv_method: RecvMethod::Serial(unsafe { serial2::SerialPort::from_raw_fd(read_fd) }),
             expected_header: ExpectedHeader::Serial,
@@ -1505,6 +1679,83 @@ mod tests {
         }
         let r = receiver.recv_msg();
         assert!(r.is_err(), "Expecting no more messages, got: {:?}", r);
+    }
+
+    #[cfg(not(windows))] // the pipe is blocking (not supporting the timeout) on windows
+    #[test]
+    fn serial_recv_non_dlt_header_split_by_timeout() {
+        let logger = new_logger();
+        // create a pipe and use the read end as serial port for the receiver
+        let (read_end, mut write_end) = std::io::pipe().expect("create pipe");
+        let read_end = std::mem::ManuallyDrop::new(read_end);
+        let read_fd = read_end.as_raw_fd();
+
+        let mut serial_port = unsafe { serial2::SerialPort::from_raw_fd(read_fd) };
+        serial_port
+            .set_read_timeout(std::time::Duration::from_millis(500))
+            .expect("set read timeout");
+
+        let receiver = IpDltMsgReceiver {
+            log: logger,
+            recv_mode: RecvMode::Serial(SerialParams {
+                device_name: "test".to_string(),
+                baudrate: 0,
+                expect_serial_header: false,
+            }),
+            recv_method: RecvMethod::Serial(serial_port),
+            expected_header: ExpectedHeader::None,
+            interface: InterfaceIndexOrAddress::Index(0),
+            addr: SocketAddr::new("127.0.0.1".parse().unwrap(), 0),
+            recv_buffer: Vec::with_capacity(65536),
+            storage_header_ecu: DltChar4::from_buf(b"EcuS"),
+            buffered_msgs: std::collections::VecDeque::new(),
+            recv_buffer_list: Vec::new(),
+            #[cfg(feature = "pcap")]
+            plp_stats: None,
+            #[cfg(feature = "pcap")]
+            fragment_cache: HashMap::new(),
+            index: 0,
+        };
+
+        use std::io::Write;
+        let recv_thread = std::thread::spawn(move || {
+            let mut receiver = receiver;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+            let mut msgs = Vec::with_capacity(2);
+            while std::time::Instant::now() < deadline && msgs.len() < 2 {
+                match receiver.recv_msg() {
+                    Ok((msg, _src_addr)) => msgs.push(msg),
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        continue;
+                    }
+                    Err(e) => panic!("recv_msg failed: {e}"),
+                }
+            }
+            assert_eq!(msgs.len(), 2, "Expected 2 messages within deadline");
+            (msgs.remove(0), msgs.remove(0))
+        });
+
+        let first_chunk = "first chunk with Ċ without line separator"; // lets test a UTF8 char as well
+        write_end
+            .write_all(first_chunk.as_bytes())
+            .expect("write first chunk to serial pipe");
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        write_end
+            .write_all(b"second chunk with line separator\n")
+            .expect("write second chunk to serial pipe");
+
+        let (msg1, msg2) = recv_thread.join().expect("join recv thread");
+
+        assert_eq!(msg1.payload_as_text().as_deref(), Ok(first_chunk));
+        assert_eq!(
+            msg2.payload_as_text().as_deref(),
+            Ok("second chunk with line separator")
+        );
     }
 
     /// MARK: UDP tests

--- a/src/utils/ipdltmsgreceiver.rs
+++ b/src/utils/ipdltmsgreceiver.rs
@@ -755,6 +755,7 @@ impl IpDltMsgReceiver {
 
         let recv_buffer = &mut self.recv_buffer.spare_capacity_mut();
 
+        let recv_capacity = recv_buffer.len();
         let (size, src_addr) = match &mut self.recv_method {
             RecvMethod::Serial(ref serial_port) => {
                 // debug!(self.log, "recv_msg: receiving message via serial");
@@ -971,6 +972,8 @@ impl IpDltMsgReceiver {
             self.recv_buffer_list.push((src_addr.clone(), data));
             &mut self.recv_buffer_list.last_mut().unwrap().1
         };
+        let had_buffered_before = !src_addr_buffer.is_empty();
+        let read_filled_capacity = size >= recv_capacity;
 
         // Safety: `recv_from` guarantees that `size` bytes are initialized in the buffer.
         // We are upholding the safety contract to only view these initialized bytes as `&[u8]`.
@@ -999,6 +1002,16 @@ impl IpDltMsgReceiver {
         let mut did_consume = 0;
         loop {
             let rem_data = &data[did_consume..];
+            if did_consume > 0 // if we filled the full buffer we do need to proceed i.e. trunk in the middle of the text anyhow
+                && matches!(self.expected_header, ExpectedHeader::None)
+                && !had_buffered_before
+                && read_filled_capacity
+                && !rem_data.iter().any(|&b| b == b'\r' || b == b'\n')
+            {
+                // A full serial read without separators can end in the middle of a text chunk.
+                // Keep the tail buffered so the next read can complete it.
+                break;
+            }
             match match self.expected_header {
                 ExpectedHeader::Std => {
                     parse_dlt_with_std_header(rem_data, self.index, self.storage_header_ecu)
@@ -1851,6 +1864,206 @@ mod tests {
             msg2.payload_as_text().as_deref(),
             Ok("second chunk with line separator")
         );
+    }
+
+    #[cfg(not(windows))] // the pipe is blocking (not supporting the timeout) on windows
+    #[test]
+    fn serial_recv_non_dlt_chunk_and_timeout_three_messages() {
+        const CHUNK_SIZE: usize = 0x10000;
+        const FIRST_TOTAL_LEN: usize = CHUNK_SIZE - 40; // includes trailing '\n'
+
+        let logger = new_logger();
+        // create a pipe and use the read end as serial port for the receiver
+        let (read_end, mut write_end) = std::io::pipe().expect("create pipe");
+        let read_end = std::mem::ManuallyDrop::new(read_end);
+        let read_fd = read_end.as_raw_fd();
+
+        let mut serial_port = unsafe { serial2::SerialPort::from_raw_fd(read_fd) };
+        serial_port
+            .set_read_timeout(std::time::Duration::from_millis(500))
+            .expect("set read timeout");
+
+        let receiver = IpDltMsgReceiver {
+            log: logger,
+            recv_mode: RecvMode::Serial(SerialParams {
+                device_name: "test".to_string(),
+                baudrate: 0,
+                expect_serial_header: false,
+            }),
+            recv_method: RecvMethod::Serial(serial_port),
+            expected_header: ExpectedHeader::None,
+            interface: InterfaceIndexOrAddress::Index(0),
+            addr: SocketAddr::new("127.0.0.1".parse().unwrap(), 0),
+            recv_buffer: Vec::with_capacity(CHUNK_SIZE),
+            storage_header_ecu: DltChar4::from_buf(b"EcuS"),
+            buffered_msgs: std::collections::VecDeque::new(),
+            recv_buffer_list: Vec::new(),
+            #[cfg(feature = "pcap")]
+            plp_stats: None,
+            #[cfg(feature = "pcap")]
+            fragment_cache: HashMap::new(),
+            index: 0,
+        };
+
+        let first_payload = "A".repeat(FIRST_TOTAL_LEN - 1);
+        let first_with_newline = format!("{first_payload}\n");
+        assert_eq!(first_with_newline.len(), FIRST_TOTAL_LEN);
+
+        let second_payload = "B".repeat(100);
+        let third_payload = "C".repeat(50);
+        let third_with_newline = format!("{third_payload}\n");
+
+        use std::io::Write;
+        let recv_thread = std::thread::spawn(move || {
+            let mut receiver = receiver;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let mut msgs = Vec::with_capacity(3);
+            while std::time::Instant::now() < deadline && msgs.len() < 3 {
+                match receiver.recv_msg() {
+                    Ok((msg, _src_addr)) => msgs.push(msg),
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        continue;
+                    }
+                    Err(e) => panic!("recv_msg failed: {e}"),
+                }
+            }
+            assert_eq!(msgs.len(), 3, "Expected 3 messages within deadline");
+            (msgs.remove(0), msgs.remove(0), msgs.remove(0))
+        });
+
+        write_end
+            .write_vectored(&[
+                IoSlice::new(first_with_newline.as_bytes()),
+                IoSlice::new(second_payload.as_bytes()),
+            ])
+            .expect("write first two chunks failed");
+
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        write_end
+            .write_all(third_with_newline.as_bytes())
+            .expect("write third chunk to serial pipe");
+
+        let (msg1, msg2, msg3) = recv_thread.join().expect("join recv thread");
+
+        assert_eq!(
+            msg1.payload_as_text().as_deref(),
+            Ok(first_payload.as_str())
+        );
+        assert_eq!(
+            msg2.payload_as_text().as_deref(),
+            Ok(second_payload.as_str())
+        );
+        assert_eq!(
+            msg3.payload_as_text().as_deref(),
+            Ok(third_payload.as_str())
+        );
+    }
+
+    #[cfg(not(windows))] // the pipe is blocking (not supporting the timeout) on windows
+    #[test]
+    fn serial_recv_non_dlt_100kb_no_separators_split_into_two_messages() {
+        const CHUNK_SIZE: usize = 0x10000;
+        const PAYLOAD_LEN: usize = 100 * 1024;
+
+        let logger = new_logger();
+        // create a pipe and use the read end as serial port for the receiver
+        let (read_end, mut write_end) = std::io::pipe().expect("create pipe");
+        let read_end = std::mem::ManuallyDrop::new(read_end);
+        let read_fd = read_end.as_raw_fd();
+
+        let mut serial_port = unsafe { serial2::SerialPort::from_raw_fd(read_fd) };
+        serial_port
+            .set_read_timeout(std::time::Duration::from_millis(500))
+            .expect("set read timeout");
+
+        let receiver = IpDltMsgReceiver {
+            log: logger,
+            recv_mode: RecvMode::Serial(SerialParams {
+                device_name: "test".to_string(),
+                baudrate: 0,
+                expect_serial_header: false,
+            }),
+            recv_method: RecvMethod::Serial(serial_port),
+            expected_header: ExpectedHeader::None,
+            interface: InterfaceIndexOrAddress::Index(0),
+            addr: SocketAddr::new("127.0.0.1".parse().unwrap(), 0),
+            recv_buffer: Vec::with_capacity(CHUNK_SIZE),
+            storage_header_ecu: DltChar4::from_buf(b"EcuS"),
+            buffered_msgs: std::collections::VecDeque::new(),
+            recv_buffer_list: Vec::new(),
+            #[cfg(feature = "pcap")]
+            plp_stats: None,
+            #[cfg(feature = "pcap")]
+            fragment_cache: HashMap::new(),
+            index: 0,
+        };
+
+        let payload = "Z".repeat(PAYLOAD_LEN);
+
+        use std::io::Write;
+        let recv_thread = std::thread::spawn(move || {
+            let mut receiver = receiver;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let mut msgs = Vec::with_capacity(2);
+
+            while std::time::Instant::now() < deadline && msgs.len() < 2 {
+                match receiver.recv_msg() {
+                    Ok((msg, _src_addr)) => msgs.push(msg),
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        continue;
+                    }
+                    Err(e) => panic!("recv_msg failed: {e}"),
+                }
+            }
+
+            assert_eq!(
+                msgs.len(),
+                2,
+                "Expected exactly 2 messages for 100KB payload"
+            );
+
+            match receiver.recv_msg() {
+                Ok((msg, _src_addr)) => panic!(
+                    "Unexpected extra message with payload {:?}",
+                    msg.payload_as_text()
+                ),
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock
+                            | std::io::ErrorKind::TimedOut
+                            | std::io::ErrorKind::InvalidInput
+                            | std::io::ErrorKind::UnexpectedEof
+                    ) => {}
+                Err(e) => panic!("recv_msg failed while checking for extra messages: {e}"),
+            }
+
+            (msgs.remove(0), msgs.remove(0))
+        });
+
+        write_end
+            .write_all(payload.as_bytes())
+            .expect("write 100KB payload to serial pipe");
+        drop(write_end);
+
+        let (msg1, msg2) = recv_thread.join().expect("join recv thread");
+        let reconstructed = format!(
+            "{}{}",
+            msg1.payload_as_text().expect("msg1 payload as text"),
+            msg2.payload_as_text().expect("msg2 payload as text")
+        );
+        assert_eq!(reconstructed.len(), PAYLOAD_LEN);
+        assert_eq!(reconstructed, payload);
     }
 
     /// MARK: UDP tests

--- a/src/utils/ipdltmsgreceiver.rs
+++ b/src/utils/ipdltmsgreceiver.rs
@@ -109,7 +109,7 @@ fn parse_dlt_without_header(
             len: (std_hdr_len + payload.len()).try_into().unwrap_or(u16::MAX),
         },
         extended_header: Some(DltExtendedHeader {
-            verb_mstp_mtin: 1,
+            verb_mstp_mtin: 0x41, // verbose=1, mstp=0 (Log), mtin=4 (Info)
             noar,
             apid: DltChar4::from_buf(b"SER\0"),
             ctid: DltChar4::from_buf(b"ASC\0"),

--- a/src/utils/ipdltmsgreceiver.rs
+++ b/src/utils/ipdltmsgreceiver.rs
@@ -46,6 +46,8 @@ fn parse_dlt_without_header(
     index: DltMessageIndexType,
     storage_header_ecu: DltChar4,
 ) -> Result<(usize, DltMessage), Error> {
+    const MAX_CHUNK_LEN: usize = (64 * 1024) - 32;
+
     if data.is_empty() {
         return Err(Error::new(ErrorKind::NotEnoughData(1)));
     }
@@ -61,11 +63,11 @@ fn parse_dlt_without_header(
 
     let payload_start = leading_separators;
     // position() is relative to data[payload_start..], so convert to absolute index in data.
-    let payload_end = data[payload_start..]
+    let full_payload_end = data[payload_start..]
         .iter()
         .position(|&b| is_sep(b))
         .map_or(data.len(), |idx| payload_start + idx);
-    let payload = &data[payload_start..payload_end];
+    let payload = &data[payload_start..full_payload_end];
     if payload.is_empty() {
         return Err(Error::new(ErrorKind::InvalidData(
             "empty payload".to_string(),
@@ -77,7 +79,14 @@ fn parse_dlt_without_header(
         .map(|d| d.as_micros() as u64)
         .unwrap_or(0);
 
-    let payload_text = std::str::from_utf8(payload).ok();
+    let mut payload_end = payload_start + payload.len().min(MAX_CHUNK_LEN);
+    if payload_end < full_payload_end && std::str::from_utf8(payload).is_ok() {
+        while payload_end > payload_start && (data[payload_end] & 0b1100_0000) == 0b1000_0000 {
+            payload_end -= 1;
+        }
+    }
+    let candidate = &data[payload_start..payload_end];
+    let payload_text = std::str::from_utf8(candidate).ok();
     let (noar, payload) = if let Some(text) = payload_text {
         crate::dlt_args!(text).map_err(|e| {
             Error::new(ErrorKind::InvalidData(format!(
@@ -85,7 +94,7 @@ fn parse_dlt_without_header(
             )))
         })?
     } else {
-        crate::dlt_args!(serde_bytes::Bytes::new(payload)).map_err(|e| {
+        crate::dlt_args!(serde_bytes::Bytes::new(candidate)).map_err(|e| {
             Error::new(ErrorKind::InvalidData(format!(
                 "failed to serialize RAW payload as verbose DLT argument: {e}"
             )))
@@ -125,10 +134,14 @@ fn parse_dlt_without_header(
         lifecycle: 0,
     };
 
-    let trailing_separators = data[payload_end..]
-        .iter()
-        .take_while(|&&b| is_sep(b))
-        .count();
+    let trailing_separators = if payload_end == full_payload_end {
+        data[payload_end..]
+            .iter()
+            .take_while(|&&b| is_sep(b))
+            .count()
+    } else {
+        0
+    };
     let to_consume = payload_end + trailing_separators;
 
     Ok((to_consume, msg))
@@ -1465,7 +1478,7 @@ impl Iterator for IpDltMsgReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dlt::DltStandardHeader;
+    use crate::dlt::{DltMessageLogType, DltStandardHeader};
     #[cfg(not(windows))]
     use crate::dlt::{DLT_SERIAL_HEADER_PATTERN, DLT_SERIAL_HEADER_SIZE};
     use crate::dlt_args;
@@ -1532,6 +1545,11 @@ mod tests {
         }
 
         assert_eq!(parsed.len(), 2);
+        // assert that the log level is info:
+        assert_eq!(
+            parsed[0].mstp(),
+            crate::dlt::DltMessageType::Log(DltMessageLogType::Info)
+        );
         assert_eq!(parsed[0].payload_as_text().as_deref(), Ok("hello"));
         assert_eq!(parsed[1].payload_as_text().as_deref(), Ok("world"));
         assert_eq!(
@@ -1562,6 +1580,77 @@ mod tests {
             }
             _ => panic!("Expected parsed raw-bytes message"),
         }
+    }
+
+    #[test]
+    fn parse_without_header_large_raw_bytes_are_split_without_data_loss() {
+        let input = vec![0xffu8; (u16::MAX as usize) * 2 + 1234];
+        let ecu = DltChar4::from_buf(b"EcuS");
+
+        let mut idx = 42;
+        let mut offset = 0usize;
+        let mut parsed_msgs = 0usize;
+        let mut reconstructed = Vec::with_capacity(input.len());
+
+        while offset < input.len() {
+            match parse_dlt_without_header(&input[offset..], idx, ecu) {
+                Ok((consumed, msg)) => {
+                    assert!(consumed > 0);
+                    offset += consumed;
+                    idx += 1;
+                    parsed_msgs += 1;
+
+                    let mut args = (&msg).into_iter();
+                    let arg = args.next().expect("expected one raw argument");
+                    assert_eq!(arg.type_info, crate::dlt::DLT_TYPE_INFO_RAWD);
+                    reconstructed.extend_from_slice(arg.payload_raw);
+                    assert!(args.next().is_none());
+                }
+                Err(e) => panic!("unexpected parse error at offset {offset}: {e}"),
+            }
+        }
+
+        assert!(
+            parsed_msgs >= 2,
+            "expected payload to be split into messages"
+        );
+        assert_eq!(reconstructed.len(), input.len());
+        assert_eq!(reconstructed, input);
+    }
+
+    #[test]
+    fn parse_without_header_utf8_split_does_not_cut_multibyte_char() {
+        const MAX_CHUNK_LEN: usize = (64 * 1024) - 32;
+
+        let mut text = "a".repeat(MAX_CHUNK_LEN - 1);
+        text.push('€');
+        text.push_str("tail");
+        let input = text.as_bytes();
+        let ecu = DltChar4::from_buf(b"EcuS");
+
+        let mut idx = 123;
+        let mut offset = 0usize;
+        let mut parsed_text = String::new();
+        let mut parsed_msgs = 0usize;
+
+        while offset < input.len() {
+            match parse_dlt_without_header(&input[offset..], idx, ecu) {
+                Ok((consumed, msg)) => {
+                    assert!(consumed > 0);
+                    offset += consumed;
+                    idx += 1;
+                    parsed_msgs += 1;
+                    parsed_text.push_str(msg.payload_as_text().as_deref().unwrap());
+                }
+                Err(e) => panic!("unexpected parse error at offset {offset}: {e}"),
+            }
+        }
+
+        assert!(
+            parsed_msgs >= 2,
+            "expected payload to be split into messages"
+        );
+        assert_eq!(parsed_text, text);
     }
 
     // MARK: serial tests


### PR DESCRIPTION
Allows to capture raw ascii/utf8 text from serial ports as DLT messages.
Messages get apid/ctid SER/ASC.
Messages are split by newlines or by a 500ms timeout.